### PR TITLE
Minor fixes, and wait_allocation function is fully implementated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "common",
+ "futures 0.3.12",
  "ipmpsc",
  "jsonrpc-http-server",
  "jsonrpc_client",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.38"
 common = { path = "../common/" }
+futures = "0.3.12"
 jsonrpc-http-server = "17.0.0"
 jsonrpc_client = { version = "0.5.0", features = ["reqwest"] }
 nix = "0.19.1"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -16,7 +16,6 @@ pub use global_mutex::GlobalMutex;
 pub use rpc_client::*;
 pub use scheduler::run_scheduler;
 
-use jsonrpc_client::Error as RpcError;
 use tokio::runtime::Runtime;
 
 use rpc_client::{Client as RpcClient, RpcClient as RpcClientTrait};
@@ -49,44 +48,56 @@ pub fn register(pid: u32, client_id: u64) -> ClientToken {
 pub fn schedule_one_of<T: Debug + Clone>(
     client: ClientToken,
     task: Task<T>,
-    _timeout: Duration,
+    timeout: Duration,
 ) -> Result<(), ClientError> {
     let address = server_address();
-    let jrpc_client = RpcClient::new(&address)?;
+    let mut jrpc_client = RpcClient::new(&address)?;
     let rt = Runtime::new().map_err(|e| ClientError::Other(e.to_string()))?;
 
-    let result = rt.block_on(async { jrpc_client.wait_allocation(task.task_req.clone()).await });
-
-    if let Ok(r) = result {
-        return r.map(|_| ());
-    }
-
-    let e = result.unwrap_err();
-    // We assume here that the returned error is of type reqwest::Error because of the feature we enabled
-    // here for the jsonrpc_client crate, if we use surf or another feature for such crate the code
-    // bellow will not work
-    if let RpcError::Client(ref e) = e {
-        // A connection type error that means the scheduler is offline
-        if e.is_connect() || e.is_timeout() {
-            #[cfg(not(test))]
+    let result = rt.block_on(async {
+        let allocation = if jrpc_client.check_server().await.is_ok() {
+            wait_allocation(&mut jrpc_client, client, task.task_req, timeout).await
+        } else {
             launch_scheduler_process(address)?;
-
-            #[cfg(test)]
-            let handle = scheduler::spawn_scheduler_with_handler(&address).unwrap();
-
             std::thread::sleep(Duration::from_millis(500));
+            wait_allocation(&mut jrpc_client, client, task.task_req, timeout).await
+        };
+        // TODO: implement the next parts of this function
+        allocation
+    });
+    result.map(|_| ())
+}
 
-            let result = rt.block_on(async { jrpc_client.wait_allocation(task.task_req).await });
-
-            #[cfg(test)]
-            handle.close();
-
-            return result
-                .map_err(|e| ClientError::RpcError(e.to_string()))?
-                .map(|_| ());
+async fn wait_allocation(
+    rpc_client: &mut RpcClient,
+    client: ClientToken,
+    requirements: TaskRequirements,
+    timeout: std::time::Duration,
+) -> Result<ResourceAlloc, ClientError> {
+    tokio::select! {
+        _ = tokio::time::timeout(timeout, futures::future::pending::<()>()) => {
+            return Err(ClientError::Timeout);
+        }
+        call_res = async {
+            loop {
+                match rpc_client.wait_allocation(client, requirements.clone()).await {
+                    Ok(Ok(dev)) => {
+                        if let Some(alloc) = dev {
+                            return Ok(alloc);
+                        } else {
+                            // There are not available resources at this point so we have to try
+                            // again.
+                            continue
+                        }
+                    }
+                    Ok(Err(e)) => return Err(e),
+                    Err(e) => return Err(ClientError::RpcError(e.to_string())),
+                }
+            }
+        } => {
+            return call_res;
         }
     }
-    Err(ClientError::Other(e.to_string()))
 }
 
 #[allow(dead_code)]
@@ -114,20 +125,24 @@ pub fn list_allocations() -> Result<Vec<u32>, ClientError> {
     let jrpc_client = RpcClient::new(&server_address())?;
     let rt = Runtime::new().map_err(|e| ClientError::Other(e.to_string()))?;
     rt.block_on(async { jrpc_client.list_allocations().await })
-        .map_err(|e| ClientError::Other(e.to_string()))?
+        .map_err(|e| ClientError::Other(e.to_string()))
+}
+
+pub fn release(alloc: ResourceAlloc) -> Result<(), ClientError> {
+    let jrpc_client = RpcClient::new(&server_address())?;
+    let rt = Runtime::new().map_err(|e| ClientError::Other(e.to_string()))?;
+    rt.block_on(async { jrpc_client.release(alloc).await })
+        .map_err(|e| ClientError::RpcError(e.to_string()))?
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn calls_scheduler_one_process() {
+    fn task<T>(t: impl Fn(Vec<ResourceAlloc>) -> TaskResult<T> + 'static) -> Task<T> {
         use chrono::{DateTime, NaiveDateTime, Utc};
-        use rand::Rng;
 
-        let task_fn =
-            Box::new(|_data: Vec<ResourceAlloc>| TaskResult::Done(Ok("HelloWorld".to_string())));
+        let task_fn = Box::new(t);
         let req = ResourceReq {
             resource: common::ResourceType::Gpu,
             quantity: 2,
@@ -138,20 +153,87 @@ mod tests {
         let start = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(61, 0), Utc);
         let end = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(61, 0), Utc);
         let deadline = Deadline::new(start, end);
-        let task = Task::new(
+        Task::new(
             task_fn,
             vec![req.clone()],
             time_per_iteration,
             exec_time,
             deadline,
-        );
+        )
+    }
+
+    #[test]
+    fn calls_scheduler_one_process() {
+        use rand::Rng;
 
         let mut rng = rand::thread_rng();
         let pid: u32 = rng.gen();
         let client_id: u64 = rng.gen();
         let token = register(pid, client_id);
 
+        let handle = scheduler::spawn_scheduler_with_handler(&server_address()).unwrap();
+
+        let task = task(|_data: Vec<ResourceAlloc>| TaskResult::Done(Ok("HelloWorld".to_string())));
+
         let res = schedule_one_of(token, task, Default::default());
+        // Accept just this type of error
+        if let Err(e) = res {
+            assert_eq!(e, ClientError::Timeout);
+        }
+        handle.close();
+    }
+
+    #[test]
+    fn allocation_test() {
+        let address = "127.0.0.1:6000".to_string();
+        let mut jrpc_client = RpcClient::new(&address).unwrap();
+        let handle = scheduler::spawn_scheduler_with_handler(&address).unwrap();
+        let rt = Runtime::new().unwrap();
+        let client = register(10, 25);
+        let task = task(|_data: Vec<ResourceAlloc>| TaskResult::Done(Ok("HelloWorld".to_string())));
+
+        let result = rt.block_on(wait_allocation(
+            &mut jrpc_client,
+            client,
+            task.task_req,
+            // How much are we eager to wait for a resource to be allocated for us?
+            std::time::Duration::from_millis(3000),
+        ));
+
+        // If there are not gpu devices attached to the system we expect a timeout error
+        if list_all_resources().gpu_devices().is_empty() {
+            assert_eq!(result.unwrap_err(), ClientError::Timeout);
+        } else {
+            assert!(result.is_ok());
+        }
+
+        handle.close();
+    }
+
+    #[test]
+    fn release_test() {
+        // This test only check communication and well formed param parsing
+        let address = "127.0.0.1:7000".to_string();
+        let jrpc_client = RpcClient::new(&address).unwrap();
+        let handle = scheduler::spawn_scheduler_with_handler(&address).unwrap();
+        let rt = Runtime::new().unwrap();
+        let res_req = ResourceReq {
+            resource: common::ResourceType::Gpu,
+            quantity: 1,
+            preemptible: true,
+        };
+        let res_alloc = ResourceAlloc {
+            resource: res_req,
+            resource_id: 0,
+        };
+
+        let res = rt
+            .block_on(async { jrpc_client.release(res_alloc).await })
+            .map_err(|e| ClientError::RpcError(e.to_string()))
+            .unwrap();
+
         assert!(res.is_ok());
+
+        handle.close();
     }
 }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1,20 +1,20 @@
-use common::{Error, ResourceAlloc, TaskRequirements};
+use common::{ClientToken, Error, ResourceAlloc, TaskRequirements};
 
 #[jsonrpc_client::api]
 pub trait RpcClient {
-    async fn wait_allocation(&self, task: TaskRequirements) -> Result<ResourceAlloc, Error>;
-
-    async fn schedule_preemptive(&self, task: String) -> Result<String, String>;
-
-    async fn wait_preemptive(
+    async fn wait_allocation(
         &self,
-        task: crate::ClientToken,
-        t: std::time::Duration,
-    ) -> Result<bool, Error>;
+        client: ClientToken,
+        task: TaskRequirements,
+    ) -> Result<Option<ResourceAlloc>, Error>;
+
+    async fn wait_preemptive(&self, task: crate::ClientToken, t: std::time::Duration) -> bool;
 
     async fn check_server(&self) -> Result<(), Error>;
 
-    async fn list_allocations(&self) -> Result<Vec<u32>, Error>;
+    async fn list_allocations(&self) -> Vec<u32>;
+
+    async fn release(&self, alloc: ResourceAlloc) -> Result<(), Error>;
 }
 
 #[jsonrpc_client::implement(RpcClient)]

--- a/common/src/client.rs
+++ b/common/src/client.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Copy, Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ClientToken {
     pub(crate) pid: u32,
     pub(crate) client_id: u64,
@@ -7,5 +7,13 @@ pub struct ClientToken {
 impl ClientToken {
     pub fn new(pid: u32, client_id: u64) -> Self {
         Self { pid, client_id }
+    }
+
+    pub fn process_id(&self) -> u32 {
+        self.pid
+    }
+
+    pub fn id(&self) -> u64 {
+        self.client_id
     }
 }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -5,6 +5,8 @@ pub enum Error {
     GlobalMutexError(String),
     RpcError(String),
     ResourceReqEmpty,
+    UnknownResource(u32),
+    Timeout,
     Other(String),
 }
 
@@ -16,6 +18,8 @@ impl fmt::Display for Error {
             }
             Error::RpcError(ref e) => write!(f, "Rpc error: {}", e),
             Error::ResourceReqEmpty => write!(f, "Requirements for task is empty"),
+            Error::UnknownResource(r) => write!(f, "Resource {} not available", r),
+            Error::Timeout => write!(f, "Timeout triggered before receiving a response "),
             Error::Other(ref descripcion) => write!(f, "Error: {}", descripcion),
         }
     }

--- a/common/src/requests.rs
+++ b/common/src/requests.rs
@@ -1,11 +1,10 @@
-use crate::ClientToken;
-use crate::TaskRequirements;
+use crate::{ClientToken, ResourceAlloc, TaskRequirements};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 pub enum RequestMethod {
-    Schedule(TaskRequirements),
+    Schedule(ClientToken, TaskRequirements),
     ListAllocations,
-    SchedulePreemptive(String),
     WaitPreemptive(ClientToken, std::time::Duration),
+    Release(ResourceAlloc),
 }

--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -15,5 +15,5 @@ pub struct ResourceReq {
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ResourceAlloc {
     pub resource: ResourceReq,
-    pub resource_id: usize,
+    pub resource_id: u32,
 }

--- a/common/src/task.rs
+++ b/common/src/task.rs
@@ -2,7 +2,7 @@ use chrono::{offset::Utc, DateTime};
 use std::error::Error;
 use std::time::Duration;
 
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::{ResourceAlloc, ResourceReq};
 
@@ -38,7 +38,7 @@ pub struct Task<T> {
     pub task_req: TaskRequirements,
 }
 
-impl<T: Serialize + DeserializeOwned> Task<T> {
+impl<T> Task<T> {
     pub fn new(
         func: impl Fn(Vec<ResourceAlloc>) -> TaskResult<T> + 'static,
         req: Vec<ResourceReq>,

--- a/scheduler/src/requests.rs
+++ b/scheduler/src/requests.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 pub enum SchedulerResponse {
-    Schedule(Result<ResourceAlloc, Error>),
-    SchedulePreemptive(String),
+    Schedule(Result<Option<ResourceAlloc>, Error>),
     SchedulerWaitPreemptive(bool),
     ListAllocations(Vec<u32>),
+    Release,
 }
 
 pub struct SchedulerRequest {


### PR DESCRIPTION
2. Implement the wait_allocation function on both sides. The client
   would try until the timeout expires or the scheduler returns Some(resource)
3. Fix the return type of the wait_preemptive and list_allocations
   functions
4. Implement the release function that returns Result<(), Error>
   although the design states It returns nothing, the client json-rpc
   library requires and sized type as a return.
5. Added test for the wait_allocation and release functions.