### PR TITLE
Fix to unit test

### DIFF
--- a/scheduler/src/linearsolver.rs
+++ b/scheduler/src/linearsolver.rs
@@ -397,70 +397,70 @@ mod tests {
         let plan: JobPlan = solve_jobschedule(reqs, 0, 0);
         assert_eq!(plan.plan.len(), jobs_data.len());
         assert_eq!(plan.makespan, 10);
-        assert_eq!(
-            plan.plan[0],
-            JobAllocation {
-                machine: 0,
-                starting_time: 0,
-                end_time: 3
-            }
-        );
-        assert_eq!(
-            plan.plan[1],
-            JobAllocation {
-                machine: 1,
-                starting_time: 4,
-                end_time: 6
-            }
-        );
-        assert_eq!(
-            plan.plan[2],
-            JobAllocation {
-                machine: 2,
-                starting_time: 0,
-                end_time: 2
-            }
-        );
-        assert_eq!(
-            plan.plan[3],
-            JobAllocation {
-                machine: 0,
-                starting_time: 3,
-                end_time: 5
-            }
-        );
-        assert_eq!(
-            plan.plan[4],
-            JobAllocation {
-                machine: 2,
-                starting_time: 2,
-                end_time: 3
-            }
-        );
-        assert_eq!(
-            plan.plan[5],
-            JobAllocation {
-                machine: 1,
-                starting_time: 6,
-                end_time: 10
-            }
-        );
-        assert_eq!(
-            plan.plan[6],
-            JobAllocation {
-                machine: 1,
-                starting_time: 0,
-                end_time: 4
-            }
-        );
-        assert_eq!(
-            plan.plan[7],
-            JobAllocation {
-                machine: 2,
-                starting_time: 3,
-                end_time: 6
-            }
-        );
+        // assert_eq!(
+        //     plan.plan[0],
+        //     JobAllocation {
+        //         machine: 0,
+        //         starting_time: 0,
+        //         end_time: 3
+        //     }
+        // );
+        // assert_eq!(
+        //     plan.plan[1],
+        //     JobAllocation {
+        //         machine: 1,
+        //         starting_time: 4,
+        //         end_time: 6
+        //     }
+        // );
+        // assert_eq!(
+        //     plan.plan[2],
+        //     JobAllocation {
+        //         machine: 2,
+        //         starting_time: 0,
+        //         end_time: 2
+        //     }
+        // );
+        // assert_eq!(
+        //     plan.plan[3],
+        //     JobAllocation {
+        //         machine: 0,
+        //         starting_time: 3,
+        //         end_time: 5
+        //     }
+        // );
+        // assert_eq!(
+        //     plan.plan[4],
+        //     JobAllocation {
+        //         machine: 2,
+        //         starting_time: 2,
+        //         end_time: 3
+        //     }
+        // );
+        // assert_eq!(
+        //     plan.plan[5],
+        //     JobAllocation {
+        //         machine: 1,
+        //         starting_time: 6,
+        //         end_time: 10
+        //     }
+        // );
+        // assert_eq!(
+        //     plan.plan[6],
+        //     JobAllocation {
+        //         machine: 1,
+        //         starting_time: 0,
+        //         end_time: 4
+        //     }
+        // );
+        // assert_eq!(
+        //     plan.plan[7],
+        //     JobAllocation {
+        //         machine: 2,
+        //         starting_time: 3,
+        //         end_time: 6
+        //     }
+        // );
         assert!(plan.is_valid());
     }
 
@@ -871,15 +871,15 @@ mod tests {
         // Machine 1: [0,4]     [4,6]     [7,11]    //Wrong in example, this could just be [6,10]!!
         // Machine 2: [5,6]     [6,8]     [8,11]
 
-        assert_eq!(sol.col(columns[1]), 0.);
-        assert_eq!(sol.col(columns[2]), 4.);
-        assert_eq!(sol.col(columns[3]), 6.);
-
-        assert_eq!(sol.col(columns[4]), 3.);
-        assert_eq!(sol.col(columns[5]), 5.);
-        assert_eq!(sol.col(columns[6]), 6.);
-
-        assert_eq!(sol.col(columns[7]), 0.);
-        assert_eq!(sol.col(columns[8]), 8.);
+        // assert_eq!(sol.col(columns[1]), 0.);
+        // assert_eq!(sol.col(columns[2]), 4.);
+        // assert_eq!(sol.col(columns[3]), 6.);
+        //
+        // assert_eq!(sol.col(columns[4]), 3.);
+        // assert_eq!(sol.col(columns[5]), 5.);
+        // assert_eq!(sol.col(columns[6]), 6.);
+        //
+        // assert_eq!(sol.col(columns[7]), 0.);
+        // assert_eq!(sol.col(columns[8]), 8.);
     }
 }


### PR DESCRIPTION
This PR removes the asserts on the exact plan that the solver gives. Due to randomization this can differ, but solutions should be optimal and valid (that is checked).