### PR TITLE
Replace task closure-wise functions with a Trait - and replace tokio:…

### DIFF
--- a/client/tests/test.rs
+++ b/client/tests/test.rs
@@ -1,9 +1,35 @@
 use std::io;
 
 use client::{
-    register, schedule_one_of, spawn_scheduler_with_handler, ResourceAlloc, Task, TaskResult,
+    register, schedule_one_of, spawn_scheduler_with_handler, ResourceAlloc, Task, TaskFunc,
+    TaskResult,
 };
 use std::time::Duration;
+
+struct Test {
+    index: usize,
+    id: usize,
+}
+
+impl Test {
+    fn new(id: usize) -> Self {
+        Self { index: 0usize, id }
+    }
+}
+
+impl TaskFunc for Test {
+    type TaskOutput = String;
+
+    fn task(&mut self, alloc: &ResourceAlloc) -> TaskResult<Self::TaskOutput> {
+        if self.index < 4 {
+            self.index += 1;
+            std::thread::sleep(Duration::from_secs(1));
+            return TaskResult::Continue;
+        }
+        tracing::info!("Client task {} Done!!! ", self.id);
+        TaskResult::Done(Ok(format!("Task {} done!!!", self.id)))
+    }
+}
 
 #[test]
 fn test_schedule() {
@@ -15,26 +41,16 @@ fn test_schedule() {
 
     let handler = spawn_scheduler_with_handler("127.0.0.1:5000").unwrap();
 
-    let mut index = 0;
-
     let mut joiner = vec![];
     for i in 0..5 {
         joiner.push(std::thread::spawn(move || {
             let client = register(i, i as u64).unwrap();
-            let func = move |_alloc: &ResourceAlloc| -> TaskResult<String> {
-                if index < 4 {
-                    index += 1;
-                    std::thread::sleep(Duration::from_secs(1));
-                    return TaskResult::Continue;
-                }
-                tracing::info!("Client task {} Done!!! ", i);
-                TaskResult::Done(Ok(format!("Task {} done!!!", i)))
-            };
-            let mut task = Task::default(func);
+            let test_func = Test::new(i as _);
+            let mut task = Task::default(test_func);
             if i == 0 {
                 task.task_req.deadline = None;
             }
-            schedule_one_of(client, &mut task, Duration::from_secs(20))
+            schedule_one_of(client, task, Duration::from_secs(20))
         }));
         std::thread::sleep(Duration::from_secs(1));
     }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -14,7 +14,7 @@ pub use error::Error;
 pub use devices::{list_devices, Device, Devices};
 pub use requests::RequestMethod;
 pub use resource::{ResourceAlloc, ResourceMemory, ResourceReq, ResourceType};
-pub use task::{Deadline, Task, TaskEstimations, TaskRequirements, TaskResult};
+pub use task::{Deadline, Task, TaskEstimations, TaskFunc, TaskRequirements, TaskResult};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Add a trait that defines the _init_, _end_, and _task_ functions. In order to make the integration with bellperson a bit easier, because we need to keep track of the iteration result internally. This is possible by defining a struct with the necessary fields and implementing the __TaskFunc__  trait on it. 