### PR TITLE
Updates to make integration easy

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,17 +1,15 @@
-mod error;
-//mod ffi;
 mod client;
 mod config;
 mod devices;
+mod error;
 mod requests;
 mod resource;
 mod task;
 
 pub use client::ClientToken;
 pub use config::{ClientConfig, Config, SchedulerConfig};
-pub use error::Error;
-//pub use ffi::{FfiResourceAlloc, FfiResourceReq};
 pub use devices::{list_devices, Device, Devices};
+pub use error::Error;
 pub use requests::RequestMethod;
 pub use resource::{ResourceAlloc, ResourceMemory, ResourceReq, ResourceType};
-pub use task::{Deadline, Result, Task, TaskEstimations, TaskFunc, TaskRequirements, TaskResult};
+pub use task::{Deadline, TaskEstimations, TaskFunc, TaskReqBuilder, TaskRequirements, TaskResult};

--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -25,3 +25,16 @@ pub struct ResourceAlloc {
     pub requirement: ResourceReq,
     pub resource_id: Vec<u32>,
 }
+
+impl Default for ResourceAlloc {
+    fn default() -> Self {
+        Self {
+            requirement: ResourceReq {
+                resource: ResourceType::Cpu,
+                quantity: 0,
+                preemptible: false,
+            },
+            resource_id: vec![],
+        }
+    }
+}


### PR DESCRIPTION
- Remove Task struct which is no longer necessary
- Add a builder for TaskRequirements
- Modify TaskFunc definition to take in an optional reference to a resource
Allocation
- Impl default for ResourceAllocation
- Modify the schedule_one_of function to take an optional
TaskRequirements and a TaskFunc implementor
- Add an execution loop for tasks that do not have a requirement which
means
they are supposed to run without allocations and scheduler's control

These changes were added in order to make the API easier to integrate/use with bellperson or any other. Partially closes #31. Still considering if the error type should be part of the Object