### PR TITLE
Stalled process handling

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -143,6 +143,10 @@ async fn execute_task<'a, T>(
             .task(Some(alloc))
             .map_err(|e| ClientError::Other(e.to_string()))?;
         release_preemptive(client).await?;
+        #[cfg(dummy_devices)]
+        if client.token.process_id() == 0 || client.token.process_id() == 2 {
+            tokio::time::sleep(Duration::from_secs(30)).await
+        }
     }
 
     task.end(Some(alloc))

--- a/client/tests/test.rs
+++ b/client/tests/test.rs
@@ -71,9 +71,12 @@ fn test_schedule() {
             let client = register(i, i as u64).unwrap();
             let mut test_func = Test::new(i as _);
             let mut task_req = task_requirements();
-            if i == 0 {
-                task_req.deadline = None;
-            }
+            // if i == 0 {
+            //     let start = chrono::Utc::now();
+            //     let end = start;
+            //     let deadline = Deadline::new(start, end);
+            //     task_req.deadline = Some(deadline);
+            // }
             schedule_one_of(
                 client,
                 &mut test_func,

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -11,6 +11,7 @@ pub enum Error {
     ResourceReqEmpty,
     UnknownResource(u32),
     Timeout,
+    WriteFailure,
     Solver(String),
     Other(String),
 }
@@ -34,6 +35,9 @@ impl fmt::Display for Error {
             Error::ResourceReqEmpty => write!(f, "Requirements for task is empty"),
             Error::UnknownResource(r) => write!(f, "Resource {} not available", r),
             Error::Timeout => write!(f, "Timeout triggered before receiving a response "),
+            Error::WriteFailure => {
+                write!(f, "Could not write to scheduler state")
+            }
             Error::Solver(ref e) => {
                 write!(f, "A solver error: {}", e)
             }

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -21,6 +21,8 @@ tokio = "1.2.0"
 tracing = "0.1.22"
 tracing-futures = "0.2.4"
 priority-queue = "1.0.5"
+chrono = { version = "0.4.19", features = ["serde"] }
+
 
 [features]
 default = ["greedy_solver"]


### PR DESCRIPTION
This PR handles stalled processes and pushes them to the back if they did not respond (with wait_preemtive calls). For now, only the first job in the queue will be checked. It also reworked wait_preemtive in several subfunctions.