### PR TITLE
Enable the unique_id for GPU devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,7 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "fil-ocl-core",
  "num_cpus",
  "rust-gpu-tools",
  "serde",

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -13,7 +13,7 @@ pub trait RpcClient {
 
     async fn check_server(&self) -> Result<(), Error>;
 
-    async fn list_allocations(&self) -> Result<Vec<(usize, u64)>, Error>;
+    async fn list_allocations(&self) -> Result<Vec<(u64, u64)>, Error>;
 
     async fn release(&self, client: ClientToken) -> Result<(), Error>;
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4.19", features = ["serde"] }
+fil-ocl-core = "0.11.4"
 num_cpus = "1.13.0"
 rust-gpu-tools = "0.3.0"
 serde = { version = "1.0.118", features = ["serde_derive"] }

--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -23,7 +23,7 @@ pub struct ResourceReq {
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ResourceAlloc {
     pub requirement: ResourceReq,
-    pub resource_id: Vec<usize>,
+    pub resource_id: Vec<u64>,
 }
 
 impl Default for ResourceAlloc {

--- a/scheduler/src/requests.rs
+++ b/scheduler/src/requests.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub enum SchedulerResponse {
     Schedule(Result<Option<ResourceAlloc>, Error>),
     SchedulerWaitPreemptive(bool),
-    ListAllocations(Result<Vec<(usize, u64)>, Error>),
+    ListAllocations(Result<Vec<(u64, u64)>, Error>),
     Release,
     ReleasePreemptive,
 }

--- a/scheduler/src/scheduler.rs
+++ b/scheduler/src/scheduler.rs
@@ -33,10 +33,9 @@ impl Scheduler {
         let state = devices
             .gpu_devices()
             .iter()
-            .enumerate()
-            .map(|(key, dev)| {
+            .map(|dev| {
                 (
-                    key,
+                    dev.device_id(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: Default::default(),
@@ -48,7 +47,7 @@ impl Scheduler {
                     },
                 )
             })
-            .collect::<HashMap<usize, ResourceState>>();
+            .collect::<HashMap<u64, ResourceState>>();
         let devices = RwLock::new(Resources(state));
         Self {
             tasks_state: RwLock::new(HashMap::new()),
@@ -182,6 +181,7 @@ impl Scheduler {
         }
     }
 
+    // returns (device_id, available memory)
     fn list_allocations(&self) -> SchedulerResponse {
         let alloc = self
             .devices
@@ -196,7 +196,7 @@ impl Scheduler {
                     None
                 }
             })
-            .collect::<Vec<(usize, u64)>>();
+            .collect::<Vec<(u64, u64)>>();
         SchedulerResponse::ListAllocations(Ok(alloc))
     }
 

--- a/scheduler/src/server.rs
+++ b/scheduler/src/server.rs
@@ -9,7 +9,7 @@ use crate::requests::{SchedulerRequest, SchedulerResponse};
 use crate::Error;
 use common::{ClientToken, RequestMethod, ResourceAlloc, TaskRequirements};
 
-type AllocationResult = std::result::Result<Vec<(usize, u64)>, Error>;
+type AllocationResult = std::result::Result<Vec<(u64, u64)>, Error>;
 
 #[rpc(server)]
 pub trait RpcMethods {

--- a/scheduler/src/solver.rs
+++ b/scheduler/src/solver.rs
@@ -58,7 +58,7 @@ impl ResourceState {
 }
 
 #[derive(Clone, Debug)]
-pub struct Resources(pub HashMap<usize, ResourceState>);
+pub struct Resources(pub HashMap<u64, ResourceState>);
 
 impl Resources {
     pub fn available_memory(&self, exclusive: bool) -> u64 {
@@ -104,25 +104,25 @@ impl Resources {
         false
     }
 
-    pub fn free_memory(&mut self, mem: &ResourceMemory, devices: &[usize]) {
+    pub fn free_memory(&mut self, mem: &ResourceMemory, devices: &[u64]) {
         for id in devices {
             let _ = self.0.get_mut(id).map(|dev| dev.free_memory(mem));
         }
     }
 
-    pub fn has_busy_resources(&self, devices: &[usize]) -> bool {
+    pub fn has_busy_resources(&self, devices: &[u64]) -> bool {
         devices
             .iter()
             .any(|id| self.0.get(id).map(|dev| dev.is_busy()).unwrap_or(false))
     }
 
-    pub fn set_busy_resources(&mut self, devices: &[usize]) {
+    pub fn set_busy_resources(&mut self, devices: &[u64]) {
         devices.iter().for_each(|id| {
             let _ = self.0.get_mut(id).map(|dev| dev.set_as_busy());
         });
     }
 
-    pub fn unset_busy_resources(&mut self, devices: &[usize]) {
+    pub fn unset_busy_resources(&mut self, devices: &[u64]) {
         devices.iter().for_each(|id| {
             let _ = self.0.get_mut(id).map(|dev| dev.set_as_free());
         });
@@ -165,7 +165,7 @@ pub trait Solver {
         &mut self,
         resources: &Resources,
         requirements: &TaskRequirements,
-    ) -> Option<(ResourceAlloc, HashMap<usize, ResourceState>)>;
+    ) -> Option<(ResourceAlloc, HashMap<u64, ResourceState>)>;
 }
 
 #[cfg(test)]
@@ -179,10 +179,9 @@ mod tests {
         let state_t1 = devices
             .gpu_devices()
             .iter()
-            .enumerate()
-            .map(|(i, dev)| {
+            .map(|dev| {
                 (
-                    i,
+                    dev.device_id(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
@@ -212,10 +211,9 @@ mod tests {
         let state_t2 = devices
             .gpu_devices()
             .iter()
-            .enumerate()
-            .map(|(i, dev)| {
+            .map(|dev| {
                 (
-                    i,
+                    dev.device_id(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 3,

--- a/scheduler/src/solvers/greedy.rs
+++ b/scheduler/src/solvers/greedy.rs
@@ -8,13 +8,13 @@ pub struct GreedySolver;
 use priority_queue::PriorityQueue;
 use std::cmp::Reverse;
 
-pub fn find_idle_gpus(resources: &Resources) -> Vec<usize> {
+pub fn find_idle_gpus(resources: &Resources) -> Vec<u64> {
     resources
         .0
         .iter()
         .filter(|(_, res)| !res.is_busy())
-        .map(|(index, _)| *index)
-        .collect::<Vec<usize>>()
+        .map(|(id, _)| *id)
+        .collect::<Vec<u64>>()
 }
 
 impl Solver for GreedySolver {
@@ -22,10 +22,7 @@ impl Solver for GreedySolver {
         &mut self,
         resources: &Resources,
         requirements: &TaskRequirements,
-    ) -> Option<(
-        ResourceAlloc,
-        std::collections::HashMap<usize, ResourceState>,
-    )> {
+    ) -> Option<(ResourceAlloc, std::collections::HashMap<u64, ResourceState>)> {
         // Use heuristic criteria for picking up a resource depending on task requirements
         // basing on the current resource load or even a greedy approach. For now we just take the
         // first that match and return
@@ -67,12 +64,12 @@ impl Solver for GreedySolver {
                         None
                     }
                 })
-                .collect::<Vec<usize>>();
+                .collect::<Vec<u64>>();
             let idle_gpus_available = optional_resources
                 .iter()
                 .cloned()
                 .filter(|b| idle_gpus.iter().any(|x| x == b))
-                .collect::<Vec<usize>>();
+                .collect::<Vec<u64>>();
 
             if idle_gpus_available.len() >= quantity {
                 options = vec![(idle_gpus_available, req.clone())];

--- a/scheduler/src/solvers/mod.rs
+++ b/scheduler/src/solvers/mod.rs
@@ -83,10 +83,9 @@ mod tests {
         let state_t1 = devices
             .gpu_devices()
             .iter()
-            .enumerate()
-            .map(|(i, dev)| {
+            .map(|dev| {
                 (
-                    i,
+                    dev.device_id(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
@@ -120,10 +119,9 @@ mod tests {
         let state_t2 = devices
             .gpu_devices()
             .iter()
-            .enumerate()
-            .map(|(i, dev)| {
+            .map(|dev| {
                 (
-                    i,
+                    dev.device_id(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
@@ -145,10 +143,9 @@ mod tests {
         let state_t3 = devices
             .gpu_devices()
             .iter()
-            .enumerate()
-            .map(|(i, dev)| {
+            .map(|dev| {
                 (
-                    i,
+                    dev.device_id(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
@@ -187,10 +184,9 @@ mod tests {
         let state_t4 = devices
             .gpu_devices()
             .iter()
-            .enumerate()
-            .map(|(i, dev)| {
+            .map(|dev| {
                 (
-                    i,
+                    dev.device_id(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,


### PR DESCRIPTION
Implement a procedure to retrieve a persistent and unique identifier for each device that remains stable between processes.
this id could be the same between devices with different vendorID. To avoid collisions the final device's "id" is the hash of the devices' name and this id.

TODO: Needs to be tested for AMD.