### PR TITLE
Returns enum for waittpreemtive + client abort via scheduler

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -128,7 +128,6 @@ async fn execute_task<'a, T, E: From<ClientError>>(
                 PreemptionResponse::Abort => {
                     warn!("Client {} aborted", client.token.process_id());
                     release_preemptive(client).await?;
-                    release(client).await?;
                     return task.end(Some(alloc));
                 }
             }

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1,4 +1,4 @@
-use common::{ClientToken, ResourceAlloc, TaskRequirements};
+use common::{ClientToken, PreemptionResponse, ResourceAlloc, TaskRequirements};
 use scheduler::Error;
 
 #[jsonrpc_client::api]
@@ -9,7 +9,7 @@ pub trait RpcClient {
         task: TaskRequirements,
     ) -> Result<Option<ResourceAlloc>, Error>;
 
-    async fn wait_preemptive(&self, client: ClientToken) -> bool;
+    async fn wait_preemptive(&self, client: ClientToken) -> Result<PreemptionResponse, Error>;
 
     async fn check_server(&self) -> Result<(), Error>;
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -6,7 +6,7 @@ mod task;
 
 pub use client::ClientToken;
 pub use devices::{list_devices, Device, Devices};
-pub use requests::RequestMethod;
+pub use requests::{PreemptionResponse, RequestMethod};
 pub use resource::{ResourceAlloc, ResourceMemory, ResourceReq, ResourceType};
 pub use task::{
     Deadline, TaskEstimations, TaskFunc, TaskReqBuilder, TaskRequirements, TaskResult, TaskType,

--- a/common/src/requests.rs
+++ b/common/src/requests.rs
@@ -11,3 +11,10 @@ pub enum RequestMethod {
     Abort(u64),
     Monitoring,
 }
+
+#[derive(Serialize, Deserialize, Eq, PartialEq)]
+pub enum PreemptionResponse {
+    Execute,
+    Wait,
+    Abort,
+}

--- a/common/src/requests.rs
+++ b/common/src/requests.rs
@@ -8,7 +8,7 @@ pub enum RequestMethod {
     WaitPreemptive(ClientToken),
     Release(ClientToken),
     ReleasePreemptive(ClientToken),
-    Abort(u64),
+    Abort(u32),
     Monitoring,
 }
 

--- a/scheduler/src/requests.rs
+++ b/scheduler/src/requests.rs
@@ -11,7 +11,7 @@ pub enum SchedulerResponse {
     ListAllocations(Result<Vec<(u64, u64)>, Error>),
     Release,
     ReleasePreemptive,
-    Abort,
+    Abort(Result<(),Error>),
     Monitoring(Result<MonitorInfo, String>),
 }
 

--- a/scheduler/src/requests.rs
+++ b/scheduler/src/requests.rs
@@ -11,7 +11,7 @@ pub enum SchedulerResponse {
     ListAllocations(Result<Vec<(u64, u64)>, Error>),
     Release,
     ReleasePreemptive,
-    Abort(Result<(),Error>),
+    Abort(Result<(), Error>),
     Monitoring(Result<MonitorInfo, String>),
 }
 

--- a/scheduler/src/requests.rs
+++ b/scheduler/src/requests.rs
@@ -1,13 +1,13 @@
 use crate::monitor::MonitorInfo;
 use crate::Error;
-use common::{RequestMethod, ResourceAlloc};
+use common::{PreemptionResponse, RequestMethod, ResourceAlloc};
 use futures::channel::oneshot;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 pub enum SchedulerResponse {
     Schedule(Result<Option<ResourceAlloc>, Error>),
-    SchedulerWaitPreemptive(bool),
+    SchedulerWaitPreemptive(Result<PreemptionResponse, Error>),
     ListAllocations(Result<Vec<(u64, u64)>, Error>),
     Release,
     ReleasePreemptive,

--- a/scheduler/src/scheduler.rs
+++ b/scheduler/src/scheduler.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use std::collections::HashMap;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicU64, AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::RwLock;
 
 use crate::config::{Settings, Task};
@@ -184,9 +184,7 @@ impl Scheduler {
         tracing::info!("scheduler: client {} wait preemtive", client.process_id());
         let state = self.tasks_state.read().unwrap();
         let current_task = state.get(&client.process_id()).ok_or(Error::RwError)?;
-        if current_task
-            .aborted
-            .load(Ordering::Relaxed){
+        if current_task.aborted.load(Ordering::Relaxed) {
             return Ok(PreemptionResponse::Abort);
         }
         current_task
@@ -309,13 +307,11 @@ impl Scheduler {
         }
     }
 
-    fn abort(&self, client: u32) -> Result<(), Error>{
+    fn abort(&self, client: u32) -> Result<(), Error> {
         tracing::warn!("aborting client {}", client);
         let state = self.tasks_state.read().unwrap();
         let current_task = state.get(&client).ok_or(Error::RwError)?;
-        current_task
-            .aborted
-            .store(true, Ordering::Relaxed);
+        current_task.aborted.store(true, Ordering::Relaxed);
         Ok(())
     }
 
@@ -368,9 +364,7 @@ impl Handler for Scheduler {
                 self.release_preemptive(client);
                 SchedulerResponse::ReleasePreemptive
             }
-            RequestMethod::Abort(client_id) => {
-                SchedulerResponse::Abort(self.abort(client_id))
-            }
+            RequestMethod::Abort(client_id) => SchedulerResponse::Abort(self.abort(client_id)),
             RequestMethod::Monitoring => SchedulerResponse::Monitoring(self.monitor()),
         };
         let _ = sender.send(response);

--- a/scheduler/src/server.rs
+++ b/scheduler/src/server.rs
@@ -8,7 +8,7 @@ use crate::handler::Handler;
 use crate::monitor::MonitorInfo;
 use crate::requests::{SchedulerRequest, SchedulerResponse};
 use crate::Error;
-use common::{ClientToken, RequestMethod, ResourceAlloc, TaskRequirements};
+use common::{ClientToken, PreemptionResponse, RequestMethod, ResourceAlloc, TaskRequirements};
 
 type AllocationResult = std::result::Result<Vec<(u64, u64)>, Error>;
 
@@ -22,7 +22,10 @@ pub trait RpcMethods {
     ) -> BoxFuture<Result<std::result::Result<Option<ResourceAlloc>, Error>>>;
 
     #[rpc(name = "wait_preemptive")]
-    fn wait_preemptive(&self, task: ClientToken) -> BoxFuture<Result<bool>>;
+    fn wait_preemptive(
+        &self,
+        task: ClientToken,
+    ) -> BoxFuture<Result<std::result::Result<PreemptionResponse, Error>>>;
 
     #[rpc(name = "list_allocations")]
     fn list_allocations(&self) -> BoxFuture<Result<AllocationResult>>;
@@ -77,7 +80,10 @@ impl<H: Handler> RpcMethods for Server<H> {
         )
     }
 
-    fn wait_preemptive(&self, client: ClientToken) -> BoxFuture<Result<bool>> {
+    fn wait_preemptive(
+        &self,
+        client: ClientToken,
+    ) -> BoxFuture<Result<std::result::Result<PreemptionResponse, Error>>> {
         let method = RequestMethod::WaitPreemptive(client);
         let (sender, receiver) = oneshot::channel();
         let request = SchedulerRequest { sender, method };
@@ -86,7 +92,7 @@ impl<H: Handler> RpcMethods for Server<H> {
             receiver
                 .map(|e| match e {
                     Ok(SchedulerResponse::SchedulerWaitPreemptive(res)) => Ok(res),
-                    _ => Ok(true),
+                    _ => unreachable!(),
                 })
                 .boxed(),
         )

--- a/scheduler/src/server.rs
+++ b/scheduler/src/server.rs
@@ -43,7 +43,7 @@ pub trait RpcMethods {
     ) -> BoxFuture<Result<std::result::Result<(), Error>>>;
 
     #[rpc(name = "abort")]
-    fn abort(&self, client: u64) -> BoxFuture<Result<std::result::Result<(), String>>>;
+    fn abort(&self, client: u32) -> BoxFuture<Result<std::result::Result<(), String>>>;
 
     #[rpc(name = "monitoring")]
     fn monitoring(&self) -> BoxFuture<Result<std::result::Result<MonitorInfo, String>>>;
@@ -150,7 +150,7 @@ impl<H: Handler> RpcMethods for Server<H> {
 
     // For some reason we can not return () here, the is a bug on the client library that
     // expects a Result, Option or a Sized type.
-    fn abort(&self, client: u64) -> BoxFuture<Result<std::result::Result<(), String>>> {
+    fn abort(&self, client: u32) -> BoxFuture<Result<std::result::Result<(), String>>> {
         let method = RequestMethod::Abort(client);
         let (sender, receiver) = oneshot::channel();
         let request = SchedulerRequest { sender, method };
@@ -158,7 +158,7 @@ impl<H: Handler> RpcMethods for Server<H> {
         Box::pin(
             receiver
                 .map(|e| match e {
-                    Ok(SchedulerResponse::Abort) => Ok(Ok(())),
+                    Ok(SchedulerResponse::Abort(_)) => Ok(Ok(())),
                     _ => unreachable!(),
                 })
                 .boxed(),

--- a/scheduler/src/solver.rs
+++ b/scheduler/src/solver.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, VecDeque};
 use crate::config::Settings;
 use crate::Error;
 use common::{Device, ResourceAlloc, ResourceMemory, ResourceReq, ResourceType, TaskRequirements};
-use std::sync::atomic::{AtomicU64, AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 /// Wrapper that add additional information regarding to the Resource
 /// memory and usage.
@@ -164,8 +164,8 @@ impl DeserializeWith for AtomicU64 {
 }
 impl SerializeWith for AtomicBool {
     fn serialize_with<S>(v: &AtomicBool, s: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         s.serialize_bool(v.load(Ordering::Relaxed))
     }
@@ -173,8 +173,8 @@ impl SerializeWith for AtomicBool {
 
 impl DeserializeWith for AtomicBool {
     fn deserialize_with<'de, D>(de: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         let s = String::deserialize(de)?;
 
@@ -202,8 +202,8 @@ pub struct TaskState {
     pub last_seen: AtomicU64,
 
     #[serde(
-    deserialize_with = "AtomicBool::deserialize_with",
-    serialize_with = "AtomicBool::serialize_with"
+        deserialize_with = "AtomicBool::deserialize_with",
+        serialize_with = "AtomicBool::serialize_with"
     )]
     pub aborted: AtomicBool,
 }

--- a/scheduler/src/solver.rs
+++ b/scheduler/src/solver.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, VecDeque};
 use crate::config::Settings;
 use crate::Error;
 use common::{Device, ResourceAlloc, ResourceMemory, ResourceReq, ResourceType, TaskRequirements};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicBool, Ordering};
 
 /// Wrapper that add additional information regarding to the Resource
 /// memory and usage.
@@ -162,6 +162,30 @@ impl DeserializeWith for AtomicU64 {
         }
     }
 }
+impl SerializeWith for AtomicBool {
+    fn serialize_with<S>(v: &AtomicBool, s: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        s.serialize_bool(v.load(Ordering::Relaxed))
+    }
+}
+
+impl DeserializeWith for AtomicBool {
+    fn deserialize_with<'de, D>(de: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+    {
+        let s = String::deserialize(de)?;
+
+        match s.parse::<bool>() {
+            Ok(value) => Ok(AtomicBool::new(value)),
+            Err(_) => Err(serde::de::Error::custom(
+                "error trying to deserialize boolean for task abort flag",
+            )),
+        }
+    }
+}
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct TaskState {
@@ -176,6 +200,12 @@ pub struct TaskState {
         serialize_with = "AtomicU64::serialize_with"
     )]
     pub last_seen: AtomicU64,
+
+    #[serde(
+    deserialize_with = "AtomicBool::deserialize_with",
+    serialize_with = "AtomicBool::serialize_with"
+    )]
+    pub aborted: AtomicBool,
 }
 
 impl Clone for TaskState {
@@ -185,6 +215,7 @@ impl Clone for TaskState {
             current_iteration: self.current_iteration,
             allocation: self.allocation.clone(),
             last_seen: AtomicU64::new(self.last_seen.load(Ordering::Relaxed)),
+            aborted: AtomicBool::new(self.aborted.load(Ordering::Relaxed)),
         }
     }
 }


### PR DESCRIPTION
This PR:
- improves the return output from waitpreemptive to be an enum wrapped in a Result
- Implements client-side aborts via scheduler using "cargo run --release -- --address 127.0.0.1:5000 abort -c 1"