### PR TITLE
add error variant for abort cases

### DIFF
--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -13,6 +13,8 @@ pub enum Error {
     Scheduler(#[from] SchedulerError),
     #[error("Can not parse the provided address")]
     InvalidAddress,
+    #[error("Job was aborted by an external client")]
+    Aborted,
     #[error("Unknown error: `{0}`")]
     Other(String),
 }


### PR DESCRIPTION
closes #81
This PR adds:

   - an Aborted error variant
   - a simplification to execute_task function
