### PR TITLE
Rename the device id function 

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -246,9 +246,7 @@ pub fn resources_as_requirements() -> Result<Vec<common::ResourceReq>, ClientErr
     // or in case there are not available. Just get the current devices inthe system and propose
     // them as a requirement
     common::list_devices().gpu_devices().iter().for_each(|dev| {
-        resources
-            .entry(dev.device_id())
-            .or_insert_with(|| dev.memory());
+        resources.entry(dev.hash()).or_insert_with(|| dev.memory());
     });
 
     // map to memory => quantity
@@ -292,10 +290,10 @@ async fn check_scheduler_service_or_launch(address: String) -> Result<(), Client
     }
 }
 
-pub fn get_device_by_id(id: u64) -> Option<common::Device> {
+pub fn get_device_by_hash(hash: u64) -> Option<common::Device> {
     let devices = common::list_devices();
     for dev in devices.gpu_devices() {
-        if dev.device_id() == id {
+        if dev.hash() == hash {
             return Some(dev.clone());
         }
     }

--- a/scheduler/src/config.rs
+++ b/scheduler/src/config.rs
@@ -83,7 +83,7 @@ impl Default for Settings {
         let all_devices = common::list_devices()
             .gpu_devices()
             .iter()
-            .map(|dev| dev.device_id())
+            .map(|dev| dev.hash()) // use the hash instead of unique id, robustness
             .collect::<Vec<_>>();
         let mut first_devices = all_devices.clone();
         first_devices.truncate(2);

--- a/scheduler/src/scheduler.rs
+++ b/scheduler/src/scheduler.rs
@@ -81,7 +81,7 @@ impl Scheduler {
             .iter()
             .map(|dev| {
                 (
-                    dev.device_id(),
+                    dev.hash(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: Default::default(),

--- a/scheduler/src/solver.rs
+++ b/scheduler/src/solver.rs
@@ -265,7 +265,7 @@ mod tests {
             .iter()
             .map(|dev| {
                 (
-                    dev.device_id(),
+                    dev.hash(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
@@ -293,7 +293,7 @@ mod tests {
             .iter()
             .map(|dev| {
                 (
-                    dev.device_id(),
+                    dev.hash(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 3,

--- a/scheduler/src/solvers/mod.rs
+++ b/scheduler/src/solvers/mod.rs
@@ -85,7 +85,7 @@ mod tests {
             .iter()
             .map(|dev| {
                 (
-                    dev.device_id(),
+                    dev.hash(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
@@ -117,11 +117,11 @@ mod tests {
             .iter()
             .map(|dev| {
                 (
-                    dev.device_id(),
+                    dev.hash(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
-                        is_busy: dev.device_id() == 0,
+                        is_busy: dev.hash() == 0,
                     },
                 )
             })
@@ -137,7 +137,7 @@ mod tests {
             .iter()
             .map(|dev| {
                 (
-                    dev.device_id(),
+                    dev.hash(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
@@ -174,11 +174,11 @@ mod tests {
             .iter()
             .map(|dev| {
                 (
-                    dev.device_id(),
+                    dev.hash(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
-                        is_busy: dev.device_id() == 0,
+                        is_busy: dev.hash() == 0,
                     },
                 )
             })
@@ -204,11 +204,11 @@ mod tests {
             .iter()
             .map(|dev| {
                 (
-                    dev.device_id(),
+                    dev.hash(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
-                        is_busy: dev.device_id() == 0,
+                        is_busy: dev.hash() == 0,
                     },
                 )
             })


### PR DESCRIPTION
This PR just update the device identification making use of the hash() in order to be more explicit. We use the hash to avoid possible collisions between unique_id in different branches. this while the uuid gets added to rust-gpu-tools