### PR TITLE
fix: move list_devices call out of the scheduler 

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -43,7 +43,7 @@ const WINNING_POST_END_DEADLINE: u64 = 20;
 // 25 mins marging of 5 mins
 const WINDOW_POST_END_DEADLINE: u64 = 1500;
 
-// for winning post this imeout is use to fallback to CPU
+// for winning post this timeout(seconds) is used to fallback to CPU
 const WINNING_POST_TIMEOUT: u64 = 10;
 
 fn server_address() -> String {
@@ -102,13 +102,14 @@ pub fn schedule_one_of<T, E: From<Error>>(
             // modify the deadline only if it is empty
             req.deadline
                 .get_or_insert(Deadline::from_secs(0, WINDOW_POST_END_DEADLINE));
-            Duration::from_secs(WINNING_POST_TIMEOUT)
+            timeout
+            
         }
         Some(TaskType::WinningPost) => {
             // modify the deadline only if it is empty
             req.deadline
                 .get_or_insert(Deadline::from_secs(0, WINNING_POST_END_DEADLINE));
-            timeout
+            Duration::from_secs(WINNING_POST_TIMEOUT)
         }
         _ => timeout,
     };

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -90,16 +90,11 @@ pub fn register<E: From<Error>>(pid: u32, client_id: u64) -> Result<Client, E> {
 pub fn schedule_one_of<T, E: From<Error>>(
     client: Client,
     task_func: &mut dyn TaskFunc<Output = T, Error = E>,
-    req: Option<TaskRequirements>,
+    mut req: TaskRequirements,
     timeout: Duration,
 ) -> Result<T, E> {
     let address = server_address();
 
-    if req.is_none() {
-        return execute_without_scheduler(task_func);
-    }
-
-    let mut req = req.unwrap();
     info!("scheduling task_type {:?}", req.task_type);
 
     let timeout = match req.task_type {

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -437,7 +437,7 @@ mod tests {
         let res = schedule_one_of(
             token,
             &mut TaskTest,
-            Some(task_requirements()),
+            task_requirements(),
             Default::default(),
         );
         // Accept just this type of error

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -46,6 +46,8 @@ const WINDOW_POST_END_DEADLINE: u64 = 1500;
 // for winning post this timeout(seconds) is used to fallback to CPU
 const WINNING_POST_TIMEOUT: u64 = 10;
 
+// this function might be removed later as this
+// setting is part of the configuration file
 fn server_address() -> String {
     if !cfg!(test) {
         // This can change so the address might come from a configuration file along other settings
@@ -103,7 +105,6 @@ pub fn schedule_one_of<T, E: From<Error>>(
             req.deadline
                 .get_or_insert(Deadline::from_secs(0, WINDOW_POST_END_DEADLINE));
             timeout
-            
         }
         Some(TaskType::WinningPost) => {
             // modify the deadline only if it is empty

--- a/client/tests/test.rs
+++ b/client/tests/test.rs
@@ -93,12 +93,7 @@ fn test_schedule() {
                 task_req.deadline = None;
             }
             //if i == 3,4 => allocated on gpu 0 or 1 or 2
-            schedule_one_of(
-                client,
-                &mut test_func,
-                Some(task_req),
-                Duration::from_secs(20),
-            )
+            schedule_one_of(client, &mut test_func, task_req, Duration::from_secs(20))
         }));
         std::thread::sleep(Duration::from_secs(2));
     }

--- a/client/tests/test.rs
+++ b/client/tests/test.rs
@@ -63,8 +63,9 @@ fn test_schedule() {
     //let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
     //tracing_subscriber::fmt().with_writer(non_blocking).init();
     tracing_subscriber::fmt().with_writer(io::stdout).init();
+    let devices = common::list_devices();
 
-    let handler = if let Ok(handle) = spawn_scheduler_with_handler("127.0.0.1:5000") {
+    let handler = if let Ok(handle) = spawn_scheduler_with_handler("127.0.0.1:5000", devices) {
         Some(handle)
     } else {
         None

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -26,12 +26,12 @@ const SETTINGS_PATH: &str = "/tmp/scheduler.toml";
 
 /// Starts a json-rpc server listening to *addr*
 #[tracing::instrument(level = "info")]
-pub fn run_scheduler(address: &str) -> Result<(), Error> {
+pub fn run_scheduler(address: &str, devices: common::Devices) -> Result<(), Error> {
     let settings = Settings::new(SETTINGS_PATH).map_err(|e| {
         tracing::error!("Error reading config file: {}", e.to_string());
         Error::InvalidConfig(e.to_string())
     })?;
-    let handler = scheduler::Scheduler::new(settings);
+    let handler = scheduler::Scheduler::new(settings, devices);
     let server = server::Server::new(handler);
     let mut io = IoHandler::new();
 
@@ -48,12 +48,15 @@ pub fn run_scheduler(address: &str) -> Result<(), Error> {
 
 #[tracing::instrument(level = "info")]
 // To be use for testing purposes
-pub fn spawn_scheduler_with_handler(address: &str) -> Result<CloseHandle, Error> {
+pub fn spawn_scheduler_with_handler(
+    address: &str,
+    devices: common::Devices,
+) -> Result<CloseHandle, Error> {
     let settings = Settings::new(SETTINGS_PATH).map_err(|e| {
         tracing::error!("Error reading config file: {}", e.to_string());
         Error::InvalidConfig(e.to_string())
     })?;
-    let handler = scheduler::Scheduler::new(settings);
+    let handler = scheduler::Scheduler::new(settings, devices);
     let server = server::Server::new(handler);
     let mut io = IoHandler::new();
 

--- a/scheduler/src/scheduler.rs
+++ b/scheduler/src/scheduler.rs
@@ -73,8 +73,7 @@ pub(crate) struct Scheduler {
 }
 
 impl Scheduler {
-    pub fn new(settings: Settings) -> Self {
-        let devices = common::list_devices();
+    pub fn new(settings: Settings, devices: common::Devices) -> Self {
         // Created a solver
         let state = devices
             .gpu_devices()


### PR DESCRIPTION
this fixes  #94
in some distributions like Debian, holding a mutex and a futex at the same time might cause a deadlock. the internal implementation of list_devices in rust-gpu-tools use a cache that is sync by a mutex., leading to this behavior 
