### PR TITLE
add assertions and imrpove job cleanup

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -154,7 +154,7 @@ async fn execute_task<'a, T, E: From<Error>>(
         match preemtive_state {
             PreemptionResponse::Wait => {}
             PreemptionResponse::Execute => {
-                trace!("client {:?} Calling task function", client.token.pid);
+                trace!("client {} Calling task function", client.token.pid);
                 let cont = task.task(Some(alloc))?;
                 trace!("Client {} task iteration completed", client.token.pid);
                 release_preemptive(client).await?;
@@ -164,7 +164,6 @@ async fn execute_task<'a, T, E: From<Error>>(
             }
             PreemptionResponse::Abort => {
                 warn!("Client {} aborted", client.token.pid);
-                release_preemptive(client).await?;
                 return Err(E::from(Error::Aborted));
             }
         }

--- a/scheduler/src/scheduler.rs
+++ b/scheduler/src/scheduler.rs
@@ -149,7 +149,6 @@ impl Scheduler {
         // prepare the task
         let task_state = TaskState {
             requirements,
-            current_iteration: 0,
             allocation: alloc.clone(),
             last_seen: AtomicU64::new(time),
             aborted: AtomicBool::new(false),
@@ -223,8 +222,7 @@ impl Scheduler {
         }
     }
 
-    // returns a boolean indicationg if the task has to wait or not according
-    // to the priority queue and the task resources
+    // checks wether the job can continue or not depending on its position in the priority queue
     #[instrument(level = "trace", skip(self), fields(pid = client.pid))]
     fn check_priority_queue(&self, client: ClientToken) -> Result<bool, Error> {
         let queue = self.jobs_queue.read();
@@ -316,7 +314,6 @@ impl Scheduler {
                     .write()
                     .free_memory(m, state.allocation.devices.as_slice());
             }
-
             (*self.jobs_queue.write()).retain(|pid| *pid != client.pid);
         } else {
             warn!("Task resources already released");
@@ -331,10 +328,11 @@ impl Scheduler {
                 .write()
                 .unset_busy_resources(&current_task.allocation.devices);
             debug!(
-                "marking resource as free {:?}",
+                "marking resource(s) as free {:?}",
                 current_task.allocation.devices
             );
-            return;
+        } else {
+            warn!("Task: {} is not in the queue - ignoring", client.pid);
         }
     }
 

--- a/scheduler/src/scheduler.rs
+++ b/scheduler/src/scheduler.rs
@@ -316,14 +316,8 @@ impl Scheduler {
                     .write()
                     .free_memory(m, state.allocation.devices.as_slice());
             }
-            // Update our plan
-            let mut solver = create_solver(None);
-            let state = self.tasks_state.read();
-            if let Ok(plan) = solver.solve_job_schedule(&*state, &self.settings) {
-                drop(state); // release the reader so writers can take it
-                debug!("new job_plan {:?} on release", plan);
-                *self.jobs_queue.write() = plan
-            }
+
+            (*self.jobs_queue.write()).retain(|pid| *pid != client.pid);
         } else {
             warn!("Task resources already released");
         }

--- a/scheduler/src/solver.rs
+++ b/scheduler/src/solver.rs
@@ -7,7 +7,6 @@ use crate::Error;
 use common::{Device, ResourceAlloc, ResourceMemory, ResourceReq, ResourceType, TaskRequirements};
 use rust_gpu_tools::opencl::GPUSelector;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use tracing::error;
 
 /// Wrapper that add additional information regarding to the Resource
 /// memory and usage.

--- a/scheduler/src/solver.rs
+++ b/scheduler/src/solver.rs
@@ -61,7 +61,7 @@ impl ResourceState {
     pub fn set_as_free(&mut self) {
         debug_assert!(
             self.is_busy,
-            "Resource already freed -> multiple process trying to use it at the same time"
+            "Resource already in used -> multiple process trying to use it at the same time"
         );
         self.is_busy = false;
     }
@@ -188,7 +188,6 @@ where
 #[derive(Debug, Deserialize, Serialize)]
 pub struct TaskState {
     pub requirements: TaskRequirements,
-    pub current_iteration: u16,
     // the list of resources this task is using
     pub allocation: ResourceAlloc,
 
@@ -211,7 +210,6 @@ impl Clone for TaskState {
     fn clone(&self) -> Self {
         Self {
             requirements: self.requirements.clone(),
-            current_iteration: self.current_iteration,
             allocation: self.allocation.clone(),
             last_seen: AtomicU64::new(self.last_seen.load(Ordering::Relaxed)),
             aborted: AtomicBool::new(self.aborted.load(Ordering::Relaxed)),
@@ -227,14 +225,6 @@ impl TaskState {
             .map_or(i64::MAX, |d| d.end_timestamp_secs())
     }
 }
-
-//#[derive(Clone, Debug)]
-//pub struct Job {
-//pub starting_time: usize,
-//pub end_time: usize,
-//pub req: ResourceReq,
-//pub resources: Vec<u32>,
-//}
 
 // Trait that is implemented by any object that can be used as a solver
 pub trait Solver {


### PR DESCRIPTION
this adds to features:
1. two assertions in debug mode to ensure that a resource is only used by one process at any time. no collisions
2. remove the job from the queue directly retaining the order/priority of the other jobs in the queue, doing so makes it unnecessary to call the solver to calculate a new plan speeding up the release function.