### PR TITLE
add support for removing stalled jobs(experimental)

### DIFF
--- a/common/src/requests.rs
+++ b/common/src/requests.rs
@@ -9,6 +9,7 @@ pub enum RequestMethod {
     Release(ClientToken),
     ReleasePreemptive(ClientToken),
     Abort(u32),
+    RemoveStalled(u32),
     Monitoring,
 }
 

--- a/scheduler/src/error.rs
+++ b/scheduler/src/error.rs
@@ -18,4 +18,6 @@ pub enum Error {
     UnknownClient,
     #[error("Solver error: `{0}`")]
     SolverOther(String),
+    #[error("Job:`{0}` is not stalling")]
+    JobNotStalling(u32),
 }

--- a/scheduler/src/requests.rs
+++ b/scheduler/src/requests.rs
@@ -13,6 +13,7 @@ pub enum SchedulerResponse {
     Release,
     ReleasePreemptive,
     Abort(Result<(), Error>),
+    RemoveStalled(Result<(), Error>),
     Monitoring(Result<MonitorInfo, String>),
 }
 

--- a/scheduler/src/scheduler.rs
+++ b/scheduler/src/scheduler.rs
@@ -358,7 +358,6 @@ impl Scheduler {
             task.requirements.task_type,
             &self.settings,
         ) {
-            drop(task);
             trace!("task is stalled, removing");
             let task = state.remove(&client).unwrap();
             (*self.jobs_queue.write()).retain(|pid| *pid != client);

--- a/scheduler/src/server.rs
+++ b/scheduler/src/server.rs
@@ -44,7 +44,10 @@ pub trait RpcMethods {
     fn release_preemptive(&self, client: ClientToken) -> BoxFuture<RpcResult<Result<(), Error>>>;
 
     #[rpc(name = "abort")]
-    fn abort(&self, client: u32) -> BoxFuture<RpcResult<Result<(), String>>>;
+    fn abort(&self, client: u32) -> BoxFuture<RpcResult<Result<(), Error>>>;
+
+    #[rpc(name = "remove_stalled")]
+    fn remove_stalled(&self, client: u32) -> BoxFuture<RpcResult<Result<(), Error>>>;
 
     #[rpc(name = "monitoring")]
     fn monitoring(&self) -> BoxFuture<RpcResult<Result<MonitorInfo, String>>>;
@@ -144,7 +147,7 @@ impl<H: Handler> RpcMethods for Server<H> {
         )
     }
 
-    fn abort(&self, client: u32) -> BoxFuture<RpcResult<Result<(), String>>> {
+    fn abort(&self, client: u32) -> BoxFuture<RpcResult<Result<(), Error>>> {
         let method = RequestMethod::Abort(client);
         let (sender, receiver) = oneshot::channel();
         let request = SchedulerRequest { sender, method };
@@ -152,7 +155,22 @@ impl<H: Handler> RpcMethods for Server<H> {
         Box::pin(
             receiver
                 .map(|e| match e {
-                    Ok(SchedulerResponse::Abort(_)) => Ok(Ok(())),
+                    Ok(SchedulerResponse::Abort(res)) => Ok(res),
+                    _ => unreachable!(),
+                })
+                .boxed(),
+        )
+    }
+
+    fn remove_stalled(&self, client: u32) -> BoxFuture<RpcResult<Result<(), Error>>> {
+        let method = RequestMethod::RemoveStalled(client);
+        let (sender, receiver) = oneshot::channel();
+        let request = SchedulerRequest { sender, method };
+        self.0.process_request(request);
+        Box::pin(
+            receiver
+                .map(|e| match e {
+                    Ok(SchedulerResponse::RemoveStalled(res)) => Ok(res),
                     _ => unreachable!(),
                 })
                 .boxed(),


### PR DESCRIPTION
this feature must be removed after the testing process is done, for now, it is useful as a tool for testing and debugging so we can check the kind of behavior this triggers.