### PR TITLE
Added a handler to catch panics in the client's task function

### DIFF
--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -17,6 +17,8 @@ pub enum Error {
     Aborted,
     #[error("No GPU resources on the system")]
     NoGpuResources,
+    #[error("Unexpected panic in task function")]
+    TaskFunctionPanics,
     #[error("Unknown error: `{0}`")]
     Other(String),
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -487,7 +487,7 @@ mod tests {
     #[test]
     fn release_test() {
         // This test only check communication and well formed param parsing
-        let address = "127.0.0.1:7000".to_string();
+        let address = server_address();
         let client = Client::new(&address, Default::default()).unwrap();
         let devices = common::list_devices();
         let handle = scheduler::spawn_scheduler_with_handler(&address, devices).unwrap();
@@ -504,15 +504,14 @@ mod tests {
                 client.release().await
             })
             .unwrap();
+        handle.close();
 
         assert!(res.is_ok());
-
-        handle.close();
     }
 
     #[test]
     fn test_panic_handler() {
-        let address = "127.0.0.1:7000".to_string();
+        let address = server_address();
         let client = Client::new(&address, Default::default()).unwrap();
         let devices = common::list_devices();
         let handle = scheduler::spawn_scheduler_with_handler(&address, devices).unwrap();
@@ -530,7 +529,6 @@ mod tests {
         );
         handle.close();
 
-        println!("{:?}", res);
         assert!(matches!(res.unwrap_err(), Error::TaskFunctionPanics));
     }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -147,6 +147,8 @@ async fn execute_task<'a, T, E: From<Error>>(
     task: &mut dyn TaskFunc<Output = T, Error = E>,
     alloc: &ResourceAlloc,
 ) -> Result<T, E> {
+    use std::panic::{catch_unwind, /*resume_unwind,*/ AssertUnwindSafe};
+
     task.init(Some(alloc))?;
     loop {
         let preemtive_state = wait_preemptive(client, timeout).await?;
@@ -155,7 +157,18 @@ async fn execute_task<'a, T, E: From<Error>>(
             PreemptionResponse::Wait => {}
             PreemptionResponse::Execute => {
                 trace!("client {} Calling task function", client.token.pid);
-                let cont = task.task(Some(alloc))?;
+                // try to handle possible panics
+                let result = catch_unwind(AssertUnwindSafe(|| task.task(Some(alloc))));
+                if let Err(_error) = result {
+                    let _ = release_preemptive(client).await;
+                    let _ = release(client).await;
+                    error!("Client {} task function panics", client.token.pid);
+                    // TODO: Invastigate if  omitting the call to resume_unwind is UD
+                    //resume_unwind(_error);
+                    // TODO: Look for ways to show the panic message. without propagating the panic
+                    return Err(E::from(Error::TaskFunctionPanics));
+                }
+                let cont = result.unwrap()?;
                 trace!("Client {} task iteration completed", client.token.pid);
                 release_preemptive(client).await?;
                 if cont == TaskResult::Done {
@@ -403,6 +416,7 @@ mod tests {
     use super::*;
 
     struct TaskTest;
+    struct TaskTestPanic;
 
     impl TaskFunc for TaskTest {
         type Output = String;
@@ -414,6 +428,19 @@ mod tests {
 
         fn task(&mut self, _alloc: Option<&ResourceAlloc>) -> Result<TaskResult, Self::Error> {
             Ok(TaskResult::Done)
+        }
+    }
+
+    impl TaskFunc for TaskTestPanic {
+        type Output = String;
+        type Error = Error;
+
+        fn end(&mut self, _: Option<&ResourceAlloc>) -> Result<Self::Output, Self::Error> {
+            Ok("HelloWorld".to_string())
+        }
+
+        fn task(&mut self, _alloc: Option<&ResourceAlloc>) -> Result<TaskResult, Self::Error> {
+            panic!();
         }
     }
 
@@ -481,5 +508,29 @@ mod tests {
         assert!(res.is_ok());
 
         handle.close();
+    }
+
+    #[test]
+    fn test_panic_handler() {
+        let address = "127.0.0.1:7000".to_string();
+        let client = Client::new(&address, Default::default()).unwrap();
+        let devices = common::list_devices();
+        let handle = scheduler::spawn_scheduler_with_handler(&address, devices).unwrap();
+        let _res_req = ResourceReq {
+            resource: common::ResourceType::Gpu(ResourceMemory::Mem(2)),
+            quantity: 1,
+            preemptible: true,
+        };
+
+        let res = schedule_one_of(
+            client,
+            &mut TaskTestPanic,
+            task_requirements(),
+            Duration::from_secs(60),
+        );
+        handle.close();
+
+        println!("{:?}", res);
+        assert!(matches!(res.unwrap_err(), Error::TaskFunctionPanics));
     }
 }

--- a/common/src/requests.rs
+++ b/common/src/requests.rs
@@ -8,8 +8,8 @@ pub enum RequestMethod {
     WaitPreemptive(ClientToken),
     Release(ClientToken),
     ReleasePreemptive(ClientToken),
-    Abort(u32),
-    RemoveStalled(u32),
+    Abort(Vec<u32>),
+    RemoveStalled(Vec<u32>),
     Monitoring,
 }
 

--- a/scheduler/src/server.rs
+++ b/scheduler/src/server.rs
@@ -44,10 +44,10 @@ pub trait RpcMethods {
     fn release_preemptive(&self, client: ClientToken) -> BoxFuture<RpcResult<Result<(), Error>>>;
 
     #[rpc(name = "abort")]
-    fn abort(&self, client: u32) -> BoxFuture<RpcResult<Result<(), Error>>>;
+    fn abort(&self, client: Vec<u32>) -> BoxFuture<RpcResult<Result<(), Error>>>;
 
     #[rpc(name = "remove_stalled")]
-    fn remove_stalled(&self, client: u32) -> BoxFuture<RpcResult<Result<(), Error>>>;
+    fn remove_stalled(&self, client: Vec<u32>) -> BoxFuture<RpcResult<Result<(), Error>>>;
 
     #[rpc(name = "monitoring")]
     fn monitoring(&self) -> BoxFuture<RpcResult<Result<MonitorInfo, String>>>;
@@ -147,7 +147,7 @@ impl<H: Handler> RpcMethods for Server<H> {
         )
     }
 
-    fn abort(&self, client: u32) -> BoxFuture<RpcResult<Result<(), Error>>> {
+    fn abort(&self, client: Vec<u32>) -> BoxFuture<RpcResult<Result<(), Error>>> {
         let method = RequestMethod::Abort(client);
         let (sender, receiver) = oneshot::channel();
         let request = SchedulerRequest { sender, method };
@@ -162,7 +162,7 @@ impl<H: Handler> RpcMethods for Server<H> {
         )
     }
 
-    fn remove_stalled(&self, client: u32) -> BoxFuture<RpcResult<Result<(), Error>>> {
+    fn remove_stalled(&self, client: Vec<u32>) -> BoxFuture<RpcResult<Result<(), Error>>> {
         let method = RequestMethod::RemoveStalled(client);
         let (sender, receiver) = oneshot::channel();
         let request = SchedulerRequest { sender, method };

--- a/scheduler/src/solvers/mod.rs
+++ b/scheduler/src/solvers/mod.rs
@@ -27,7 +27,7 @@ mod tests {
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
-                        is_busy: false,
+                        current_task: Some(1),
                     },
                 )
             })
@@ -55,12 +55,13 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(i, dev)| {
+                let current_task = if i == 0 { Some(i as u32) } else { None };
                 (
                     dev.device_id(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
-                        is_busy: i == 0,
+                        current_task,
                     },
                 )
             })
@@ -80,7 +81,7 @@ mod tests {
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
-                        is_busy: true,
+                        current_task: Some(0),
                     },
                 )
             })
@@ -112,13 +113,13 @@ mod tests {
             .gpu_devices()
             .iter()
             .enumerate()
-            .map(|(i, dev)| {
+            .map(|(_, dev)| {
                 (
                     dev.device_id(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
-                        is_busy: i == 0,
+                        current_task: Some(0),
                     },
                 )
             })
@@ -143,13 +144,13 @@ mod tests {
             .gpu_devices()
             .iter()
             .enumerate()
-            .map(|(i, dev)| {
+            .map(|(_, dev)| {
                 (
                     dev.device_id(),
                     ResourceState {
                         dev: dev.clone(),
                         mem_usage: 0,
-                        is_busy: i == 0,
+                        current_task: Some(0),
                     },
                 )
             })


### PR DESCRIPTION
This adds a handler that might catch panics that can happen when calling the `TaskFunc::task` function.
it could be extended to be used in the `TaskFunc::init` and `TaskFunc::end` functions as well.

closes #108 