### PR TITLE
- creates a TaskId type as an identifier for tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.4",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,7 +223,8 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-http-server",
- "nix",
+ "nix 0.22.0",
+ "palaver",
  "rand 0.8.4",
  "reqwest",
  "rust-gpu-tools",
@@ -259,7 +272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
 dependencies = [
  "lazy_static",
- "nom",
+ "nom 5.1.2",
  "rust-ini",
  "serde 1.0.126",
  "serde-hjson",
@@ -701,6 +714,15 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -790,10 +812,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heapless"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74911a68a1658cfcfb61bc0ccfbd536e3b6e906f8c2f7883ee50157e3e2184f1"
+dependencies = [
+ "as-slice",
+ "generic-array 0.13.3",
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1182,6 +1225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1416,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+ "void",
+]
+
+[[package]]
+name = "nix"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
@@ -1380,6 +1445,12 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
 
 [[package]]
 name = "nom"
@@ -1568,6 +1639,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "palaver"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49dfc200733ac34dcd9a1e4a7e454b521723936010bef3710e2d8024a32d685f"
+dependencies = [
+ "bitflags",
+ "heapless",
+ "lazy_static",
+ "libc",
+ "mach",
+ "nix 0.15.0",
+ "procinfo",
+ "typenum",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,6 +1789,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "procinfo"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab1427f3d2635891f842892dda177883dca0639e05fe66796a62c9d2f23b49c"
+dependencies = [
+ "byteorder",
+ "libc",
+ "nom 2.2.1",
+ "rustc_version 0.2.3",
 ]
 
 [[package]]
@@ -1963,6 +2063,15 @@ checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
@@ -2052,11 +2161,20 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -2064,6 +2182,12 @@ name = "semver"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -2210,6 +2334,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -2605,6 +2735,12 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "want"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = "1.0.26"
 jsonrpc-core = "17.1.0"
 jsonrpc-core-client = { version = "17.1.0", features = ["http"] }
 rust-gpu-tools = { version = "0.3.0", git = "https://github.com/Zondax/rust-gpu-tools.git" , branch = "unique_id" , features = ["serde_support"]}
+palaver = "0.2.8"
 
 [dev-dependencies]
 ipmpsc = "0.5.1"

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -60,7 +60,7 @@ impl RpcCaller {
             .call_method(
                 "wait_preemptive",
                 "Result<PreemptionResponse, Error>",
-                (self.inner.token,),
+                (self.inner.token.clone(),),
             )
             .await
     }
@@ -93,7 +93,7 @@ impl RpcCaller {
             .call_method(
                 "wait_allocation",
                 "Result<Option<ResourceAlloc>, Error>>",
-                (self.inner.token, task, job_context),
+                (self.inner.token.clone(), task, job_context),
             )
             .await
     }
@@ -101,7 +101,7 @@ impl RpcCaller {
     pub async fn release(&self) -> RpcResult<Result<(), Error>> {
         self.handler
             .0
-            .call_method("release", "Result<(), Error>>", (self.inner.token,))
+            .call_method("release", "Result<(), Error>>", (self.inner.token.clone(),))
             .await
     }
 
@@ -111,7 +111,7 @@ impl RpcCaller {
             .call_method(
                 "release_preemptive",
                 "Result<(), Error>>",
-                (self.inner.token,),
+                (self.inner.token.clone(),),
             )
             .await
     }

--- a/client/tests/test.rs
+++ b/client/tests/test.rs
@@ -115,8 +115,7 @@ fn test_schedule() {
     for i in 0..4 {
         let state = devices_state.clone();
         joiner.push(std::thread::spawn(move || {
-            let client =
-                register::<Error>(i, i as u64, Some(format!("{}:{}", file!(), line!()))).unwrap();
+            let client = register::<Error>(None, Some(format!("{}:{}", file!(), line!()))).unwrap();
             let mut test_func = Test::new(i as _, state);
 
             let mut task_req = task_requirements();

--- a/common/src/client.rs
+++ b/common/src/client.rs
@@ -1,5 +1,7 @@
-#[derive(Copy, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub type TaskId = u64;
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct ClientToken {
-    pub pid: u32,
-    pub client_id: u64,
+    pub pid: TaskId,
+    pub name: String,
 }

--- a/common/src/devices.rs
+++ b/common/src/devices.rs
@@ -1,9 +1,9 @@
 #[cfg(not(dummy_devices))]
 use std::hash::{Hash, Hasher};
 
+use rust_gpu_tools::opencl::GPUSelector;
 #[cfg(not(dummy_devices))]
 use rust_gpu_tools::opencl::{Device as ClDevice, DeviceUuid};
-use rust_gpu_tools::opencl::GPUSelector;
 
 #[cfg(not(dummy_devices))]
 #[derive(Debug, Clone)]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,14 +1,13 @@
-pub use client::ClientToken;
-pub use devices::{Device, Devices, list_devices};
-pub use requests::{PreemptionResponse, RequestMethod};
-pub use resource::{ResourceAlloc, ResourceMemory, ResourceReq, ResourceType};
-pub use task::{
-    Deadline, TaskEstimations, TaskFunc, TaskReqBuilder, TaskRequirements, TaskResult, TaskType,
-};
-
 mod client;
 mod devices;
 mod requests;
 mod resource;
 mod task;
 
+pub use client::{ClientToken, TaskId};
+pub use devices::{list_devices, Device, Devices};
+pub use requests::{PreemptionResponse, RequestMethod};
+pub use resource::{ResourceAlloc, ResourceMemory, ResourceReq, ResourceType};
+pub use task::{
+    Deadline, TaskEstimations, TaskFunc, TaskReqBuilder, TaskRequirements, TaskResult, TaskType,
+};

--- a/common/src/requests.rs
+++ b/common/src/requests.rs
@@ -1,3 +1,4 @@
+use crate::client::TaskId;
 use serde::{Deserialize, Serialize};
 
 use crate::{ClientToken, TaskRequirements};
@@ -9,8 +10,8 @@ pub enum RequestMethod {
     WaitPreemptive(ClientToken),
     Release(ClientToken),
     ReleasePreemptive(ClientToken),
-    Abort(Vec<u32>),
-    RemoveStalled(Vec<u32>),
+    Abort(Vec<TaskId>),
+    RemoveStalled(Vec<TaskId>),
     Monitoring,
 }
 

--- a/common/src/task.rs
+++ b/common/src/task.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use chrono::{DateTime, offset::Utc};
+use chrono::{offset::Utc, DateTime};
 use serde::{Deserialize, Serialize};
 
 use super::{ResourceAlloc, ResourceReq};
@@ -34,8 +34,8 @@ pub enum TaskType {
 //this is more appropriate here, unless this is VERY specific
 impl TaskType {
     pub fn deserialize_with<'de, D>(de: D) -> Result<Self, D::Error>
-        where
-            D: serde::de::Deserializer<'de>,
+    where
+        D: serde::de::Deserializer<'de>,
     {
         let mut s = String::deserialize(de)?;
         s.make_ascii_lowercase();

--- a/scheduler/src/error.rs
+++ b/scheduler/src/error.rs
@@ -1,3 +1,5 @@
+use common::TaskId;
+
 #[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
 pub enum Error {
     #[error("Invalid address format")]
@@ -19,5 +21,5 @@ pub enum Error {
     #[error("Solver error: `{0}`")]
     SolverOther(String),
     #[error("Job:`{0}` is not stalling")]
-    JobNotStalling(u32),
+    JobNotStalling(TaskId),
 }

--- a/scheduler/src/monitor.rs
+++ b/scheduler/src/monitor.rs
@@ -1,18 +1,18 @@
 use rust_gpu_tools::opencl::GPUSelector;
 use serde::{Deserialize, Serialize};
 
-use common::{Deadline, ResourceAlloc, TaskType};
+use common::{Deadline, ResourceAlloc, TaskId, TaskType};
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone)]
 pub struct MonitorInfo {
     pub task_states: Vec<Task>,
     pub resources: Vec<GpuResource>,
-    pub job_plan: Vec<u32>,
+    pub job_plan: Vec<TaskId>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Task {
-    pub id: u32,
+    pub id: TaskId,
     pub alloc: ResourceAlloc,
     pub task_type: Option<TaskType>,
     pub deadline: Option<Deadline>,

--- a/scheduler/src/requests.rs
+++ b/scheduler/src/requests.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use common::{PreemptionResponse, RequestMethod, ResourceAlloc};
 
-use crate::Error;
 use crate::monitor::MonitorInfo;
+use crate::Error;
 
 #[derive(Serialize, Deserialize)]
 pub enum SchedulerResponse {

--- a/scheduler/src/solvers/greedy.rs
+++ b/scheduler/src/solvers/greedy.rs
@@ -4,7 +4,7 @@ use crate::config::Settings;
 use crate::scheduler::task_is_stalled;
 use crate::solver::{ResourceState, Resources, Solver, TaskState};
 use crate::Error;
-use common::{ResourceAlloc, TaskRequirements};
+use common::{ResourceAlloc, TaskId, TaskRequirements};
 
 use priority_queue::PriorityQueue;
 use rust_gpu_tools::opencl::GPUSelector;
@@ -92,9 +92,9 @@ impl Solver for GreedySolver {
 
     fn solve_job_schedule(
         &mut self,
-        input: &HashMap<u32, TaskState>,
+        input: &HashMap<TaskId, TaskState>,
         scheduler_settings: &Settings,
-    ) -> Result<VecDeque<u32>, Error> {
+    ) -> Result<VecDeque<TaskId>, Error> {
         // Criterion A; If the job is marked as stalled, it will be moved at the end of the queue.
         //
         // Criterion B: Use task deadline as a priority indicator. The sooner the deadline the higher
@@ -129,7 +129,7 @@ impl Solver for GreedySolver {
         Ok(priority_queue
             .into_sorted_iter()
             .map(|(i, _)| *i)
-            .collect::<VecDeque<u32>>())
+            .collect::<VecDeque<TaskId>>())
     }
 }
 

--- a/scheduler/src/solvers/mod.rs
+++ b/scheduler/src/solvers/mod.rs
@@ -12,7 +12,7 @@ pub(crate) fn create_solver(_config: Option<&Settings>) -> Box<dyn Solver> {
 mod tests {
     use super::*;
     use crate::solver::{ResourceState, Resources};
-    use common::{ResourceMemory, ResourceReq, ResourceType, TaskRequirements};
+    use common::{ResourceMemory, ResourceReq, ResourceType, TaskId, TaskRequirements};
     use std::collections::HashMap;
 
     #[test]
@@ -55,7 +55,7 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(i, dev)| {
-                let current_task = if i == 0 { Some(i as u32) } else { None };
+                let current_task = if i == 0 { Some(i as TaskId) } else { None };
                 (
                     dev.device_id(),
                     ResourceState {
@@ -114,7 +114,7 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(i, dev)| {
-                let current_task = if i == 0 { Some(i as u32) } else { None };
+                let current_task = if i == 0 { Some(i as TaskId) } else { None };
                 (
                     dev.device_id(),
                     ResourceState {
@@ -146,7 +146,7 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(i, dev)| {
-                let current_task = if i == 0 { Some(i as u32) } else { None };
+                let current_task = if i == 0 { Some(i as TaskId) } else { None };
                 (
                     dev.device_id(),
                     ResourceState {


### PR DESCRIPTION
- use the palaver crate to get a unique and valid thread id
- refactor the ClientToken replacing the client_id by a name field
- improve logging to use the new name field
- minor formatting fixes