### PR TITLE
feat: Set the deafult configuration path to the users config dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,7 +2043,7 @@ name = "rust-gpu-tools"
 version = "0.3.0"
 source = "git+https://github.com/Zondax/rust-gpu-tools.git?branch=unique_id#30a572d105367d0a16c6349000286740b9be9e74"
 dependencies = [
- "dirs",
+ "dirs 2.0.2",
  "fil-ocl",
  "hex",
  "lazy_static",
@@ -2114,6 +2123,7 @@ dependencies = [
  "coin_cbc",
  "common",
  "config",
+ "dirs 3.0.2",
  "futures 0.3.15",
  "itertools",
  "jsonrpc-core",

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -27,4 +27,5 @@ toml = "0.5.8"
 chrono = "0.4.19"
 rust-gpu-tools = { version = "0.3.0", git = "https://github.com/Zondax/rust-gpu-tools.git" , branch = "unique_id", features = ["serde_support"]}
 parking_lot = "0.11.1"
+dirs = "3.0.2"
 

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -39,7 +39,7 @@ fn get_config_path() -> Result<PathBuf, Error> {
     // check that the dirs exist otherwise create them if possible
     if !path.is_dir() {
         std::fs::create_dir_all(&path)
-            .map_err(|e| Error::Other(format!("can not create config dir {}", e.to_string())))?;
+            .map_err(|e| Error::Other(format!("cannot create config dir {}", e.to_string())))?;
     }
     path.push(SCHEDULER_CONFIG_NAME);
     Ok(path)

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -22,14 +22,34 @@ use std::net::SocketAddr;
 use jsonrpc_http_server::jsonrpc_core::IoHandler;
 use jsonrpc_http_server::CloseHandle;
 use jsonrpc_http_server::ServerBuilder;
+use std::path::PathBuf;
 
-// check if defining this as an ev variable is more convenient
-const SETTINGS_PATH: &str = "/tmp/scheduler.toml";
+const SCHEDULER_CONFIG_NAME: &str = "scheduler.toml";
+
+fn get_config_path() -> Result<PathBuf, Error> {
+    let mut path = if let Ok(val) = std::env::var("SCHEDULER_CONFIG_PATH") {
+        let path: PathBuf = val.into();
+        path
+    } else {
+        let mut path =
+            dirs::config_dir().ok_or_else(|| Error::Other("Unsuported platform".to_string()))?;
+        path.push("filecoin/");
+        path
+    };
+    // check that the dirs exist otherwise create them if possible
+    if !path.is_dir() {
+        std::fs::create_dir_all(&path)
+            .map_err(|e| Error::Other(format!("can not create config dir {}", e.to_string())))?;
+    }
+    path.push(SCHEDULER_CONFIG_NAME);
+    Ok(path)
+}
 
 /// Starts a json-rpc server listening to *addr*
 #[tracing::instrument(level = "info")]
 pub fn run_scheduler(address: &str, devices: common::Devices) -> Result<(), Error> {
-    let settings = Settings::new(SETTINGS_PATH).map_err(|e| {
+    let path = get_config_path()?;
+    let settings = Settings::new(path).map_err(|e| {
         error!(err = %e, "Error reading config file");
         Error::InvalidConfig(e.to_string())
     })?;
@@ -54,7 +74,8 @@ pub fn spawn_scheduler_with_handler(
     address: &str,
     devices: common::Devices,
 ) -> Result<CloseHandle, Error> {
-    let settings = Settings::new(SETTINGS_PATH).map_err(|e| {
+    let path = get_config_path()?;
+    let settings = Settings::new(path).map_err(|e| {
         error!(err = %e, "Error reading config file");
         Error::InvalidConfig(e.to_string())
     })?;

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -32,7 +32,7 @@ fn get_config_path() -> Result<PathBuf, Error> {
         path
     } else {
         let mut path =
-            dirs::config_dir().ok_or_else(|| Error::Other("Unsuported platform".to_string()))?;
+            dirs::config_dir().ok_or_else(|| Error::Other("Unsupported platform".to_string()))?;
         path.push("filecoin/");
         path
     };


### PR DESCRIPTION
unless the user defines a custom path through the __SCHEDULER_CONFIG_PATH__ env variable, the default path of the scheduler configuration would be something like:
`/home/user/.config/filecoin/scheduler.toml`

closes #113