### PR TITLE
Maintenance thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,8 +323,22 @@ dependencies = [
  "crossbeam-channel 0.4.4",
  "crossbeam-deque 0.7.3",
  "crossbeam-epoch 0.8.2",
- "crossbeam-queue",
+ "crossbeam-queue 0.2.3",
  "crossbeam-utils 0.7.2",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel 0.5.1",
+ "crossbeam-deque 0.8.0",
+ "crossbeam-epoch 0.9.5",
+ "crossbeam-queue 0.3.2",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -406,6 +420,16 @@ dependencies = [
  "cfg-if 0.1.10",
  "crossbeam-utils 0.7.2",
  "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -1858,7 +1882,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084325f9fb9f2c23e4c225be1a4799583badd1666c3c6bbc67bacc6147f20ba1"
 dependencies = [
- "crossbeam",
+ "crossbeam 0.7.3",
  "futures 0.1.31",
 ]
 
@@ -2178,6 +2202,7 @@ dependencies = [
  "coin_cbc",
  "common",
  "config",
+ "crossbeam 0.8.1",
  "dirs 3.0.2",
  "futures 0.3.15",
  "itertools",

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -305,21 +305,18 @@ fn launch_scheduler_process(address: String) -> Result<(), Error> {
             })?;
             match mutex.try_lock() {
                 Ok(_) => {
-                    let handler = std::thread::spawn(move || {
-                        let mut retries = START_SERVER_RETRIES;
-                        while let Err(e) = run_scheduler(&address, devices.clone()) {
-                            error!(err = %e,"Got error trying to start the server");
-                            retries -= 1;
-                            if retries == 0 {
-                                return Err(Error::Other(format!(
-                                    "Can not start scheduler service: {}",
-                                    e.to_string()
-                                )));
-                            }
+                    let mut retries = START_SERVER_RETRIES;
+                    while let Err(e) = run_scheduler(&address, devices.clone()) {
+                        error!(err = %e,"Got error trying to start the server");
+                        retries -= 1;
+                        if retries == 0 {
+                            return Err(Error::Other(format!(
+                                "Can not start scheduler service: {}",
+                                e.to_string()
+                            )));
                         }
-                        Ok(())
-                    });
-                    handler.join().expect("The scheduler lock holder panics")
+                    }
+                    Ok(())
                 }
                 Err(e) => {
                     error!(err = %e,"Error acquiring lock");

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -30,4 +30,5 @@ parking_lot = "0.11.1"
 dirs = "3.0.2"
 sysinfo = "0.19.2"
 palaver = "0.2.8"
+crossbeam = "0.8.1"
 

--- a/scheduler/src/config.rs
+++ b/scheduler/src/config.rs
@@ -7,6 +7,8 @@ use tracing::error;
 
 use common::TaskType;
 
+const MAINTENANCE_INTERVAL: u64 = 10000;
+
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Task {
     exec_time: u64,
@@ -75,6 +77,9 @@ where
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 pub struct Service {
     address: String,
+    /// interval in milliseconds. if present in the configuration file, creates a thread that performs some maintenance
+    /// operations such as removing tasks that no longer exist in the system.
+    pub maintenance_interval: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
@@ -93,6 +98,7 @@ impl Default for Settings {
     fn default() -> Self {
         let service = Service {
             address: "127.0.0.1:5000".to_string(),
+            maintenance_interval: Some(MAINTENANCE_INTERVAL),
         };
 
         let time_settings = TimeSettings { min_wait_time: 120 };

--- a/scheduler/src/handler.rs
+++ b/scheduler/src/handler.rs
@@ -2,4 +2,5 @@ use crate::requests::SchedulerRequest;
 
 pub trait Handler: Send + Sync + 'static {
     fn process_request(&self, request: SchedulerRequest);
+    fn maintenance(&self) {}
 }

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -53,8 +53,12 @@ pub fn run_scheduler(address: &str, devices: common::Devices) -> Result<(), Erro
         error!(err = %e, "Error reading config file");
         Error::InvalidConfig(e.to_string())
     })?;
+    let maintenance_interval = settings.service.maintenance_interval;
     let handler = scheduler::Scheduler::new(settings, devices);
     let server = Server::new(handler);
+    if let Some(tick) = maintenance_interval {
+        server.start_maintenance_thread(tick);
+    }
     let mut io = IoHandler::new();
 
     let address: SocketAddr = address.parse().map_err(|_| Error::InvalidAddress)?;


### PR DESCRIPTION
- creates a maintenance thread for faster detection/removal of tasks whose process does not exist in the system.
- this maintenance thread will be used for automatic shutdown as well.
- remove unnecessary thread on the client-side, the run_scheduler() function will take care of launching the scheduler service thread.