### PR TITLE
Implement the automatic shutdown feature if service is inactive

### DIFF
--- a/scheduler/src/config.rs
+++ b/scheduler/src/config.rs
@@ -8,6 +8,7 @@ use tracing::error;
 use common::TaskType;
 
 const MAINTENANCE_INTERVAL: u64 = 10000;
+const SHUTDOWN_TIMEOUT: u64 = 300;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Task {
@@ -78,8 +79,13 @@ where
 pub struct Service {
     address: String,
     /// interval in milliseconds. if present in the configuration file, creates a thread that performs some maintenance
-    /// operations such as removing tasks that no longer exist in the system.
+    /// operations such as removing tasks that no longer exist in the system or automatic shutdown
+    /// if there are not more tasks or requests.
     pub maintenance_interval: Option<u64>,
+    /// Time in seconds until the service should close itself if there are not more clients or
+    /// requests. This is done only if the [Service::maintenance_interval] setting is set in the
+    /// configuration.
+    pub shutdown_timeout: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
@@ -99,6 +105,7 @@ impl Default for Settings {
         let service = Service {
             address: "127.0.0.1:5000".to_string(),
             maintenance_interval: Some(MAINTENANCE_INTERVAL),
+            shutdown_timeout: Some(SHUTDOWN_TIMEOUT),
         };
 
         let time_settings = TimeSettings { min_wait_time: 120 };

--- a/scheduler/src/handler.rs
+++ b/scheduler/src/handler.rs
@@ -2,5 +2,11 @@ use crate::requests::SchedulerRequest;
 
 pub trait Handler: Send + Sync + 'static {
     fn process_request(&self, request: SchedulerRequest);
-    fn maintenance(&self) {}
+
+    // Perform  a maintenance iteration on this handler instance.
+    // returns True if the maintenance cycle should continue, otherwise the maintennace thread will
+    // be closed
+    fn maintenance(&self) -> bool {
+        false
+    }
 }

--- a/scheduler/src/handler.rs
+++ b/scheduler/src/handler.rs
@@ -4,7 +4,7 @@ pub trait Handler: Send + Sync + 'static {
     fn process_request(&self, request: SchedulerRequest);
 
     // Perform  a maintenance iteration on this handler instance.
-    // returns True if the maintenance cycle should continue, otherwise the maintennace thread will
+    // returns True if the maintenance cycle should continue, otherwise it will be closed
     // be closed
     fn maintenance(&self) -> bool {
         false


### PR DESCRIPTION
this adds:

- Add a shutdown_timeout to the service settings
which is used to close the service if there are no jobs
- implement the automatic shutdown mechanism which is triggered if The maintenance thread is active and the shutdown_timeout has expired and the service is kept inactive all that time.

closes #131 