### PR TITLE
Use config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,18 +56,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "base64"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -115,7 +109,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -144,9 +138,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cast"
@@ -184,7 +178,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.14",
- "serde 1.0.127",
+ "serde 1.0.129",
  "time",
  "winapi 0.3.9",
 ]
@@ -200,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "cl3"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e162e5fd0310c1060ab86ca788bf8660f916cbba7473b1c1cb1ecac8e663b9e2"
+checksum = "68fdb522345cabcdd77098487d15632dd39e79ec50ccdc81073bf534b55b3da7"
 dependencies = [
  "cl-sys",
  "libc",
@@ -226,21 +220,18 @@ dependencies = [
  "chrono",
  "common",
  "criterion",
+ "dirs 3.0.2",
  "fs2",
- "futures 0.3.16",
  "ipmpsc",
  "jsonrpc-core",
  "jsonrpc-core-client",
- "jsonrpc-http-server",
- "nix 0.22.0",
+ "nix 0.22.1",
  "once_cell",
- "palaver",
  "rand 0.8.4",
- "reqwest",
  "scheduler",
- "serde 1.0.127",
+ "serde 1.0.129",
  "thiserror",
- "tokio 0.2.25",
+ "tokio",
  "tracing",
  "tracing-appender",
  "tracing-futures",
@@ -253,8 +244,9 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "num_cpus",
+ "palaver",
  "rust-gpu-tools",
- "serde 1.0.127",
+ "serde 1.0.129",
  "tracing",
 ]
 
@@ -267,7 +259,7 @@ dependencies = [
  "lazy_static",
  "nom 5.1.2",
  "rust-ini",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -279,16 +271,6 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "core-foundation"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "core-foundation-sys"
@@ -332,7 +314,7 @@ dependencies = [
  "plotters",
  "rayon",
  "regex",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_cbor",
  "serde_derive",
  "serde_json",
@@ -428,7 +410,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -514,15 +496,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,31 +506,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
-dependencies = [
- "matches",
- "percent-encoding 2.1.0",
-]
 
 [[package]]
 name = "fs2"
@@ -773,29 +721,10 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.25",
- "tokio-util 0.3.1",
+ "tokio",
+ "tokio-util",
  "tracing",
  "tracing-futures",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
-dependencies = [
- "bytes 1.0.1",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio 1.9.0",
- "tokio-util 0.6.7",
- "tracing",
 ]
 
 [[package]]
@@ -852,7 +781,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
- "bytes 1.0.1",
+ "bytes 1.1.0",
  "fnv",
  "itoa",
 ]
@@ -868,33 +797,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
-dependencies = [
- "bytes 1.0.1",
- "http",
- "pin-project-lite 0.2.7",
-]
-
-[[package]]
 name = "httparse"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
-
-[[package]]
-name = "httpdate"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
@@ -906,55 +818,18 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.2.7",
+ "h2",
  "http",
- "http-body 0.3.1",
+ "http-body",
  "httparse",
- "httpdate 0.3.2",
+ "httpdate",
  "itoa",
  "pin-project",
- "socket2 0.3.19",
- "tokio 0.2.25",
+ "socket2",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
-]
-
-[[package]]
-name = "hyper"
-version = "0.14.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
-dependencies = [
- "bytes 1.0.1",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.3",
- "http",
- "http-body 0.4.3",
- "httparse",
- "httpdate 1.0.1",
- "itoa",
- "pin-project-lite 0.2.7",
- "socket2 0.4.1",
- "tokio 1.9.0",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes 1.0.1",
- "hyper 0.14.11",
- "native-tls",
- "tokio 1.9.0",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -962,17 +837,6 @@ name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1017,19 +881,13 @@ dependencies = [
  "hex",
  "libc",
  "memmap2",
- "serde 1.0.127",
+ "serde 1.0.129",
  "sha2 0.9.5",
  "tempfile",
  "thiserror",
  "vergen",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -1042,15 +900,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "js-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
+checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1063,14 +921,14 @@ checksum = "a2f81014e2706fde057e9dcb1036cf6bbf9418d972c597be5c7158c984656722"
 dependencies = [
  "derive_more",
  "futures 0.3.16",
- "hyper 0.13.10",
+ "hyper",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
- "tokio 0.2.25",
- "url 1.7.2",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -1083,7 +941,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "log",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_derive",
  "serde_json",
 ]
@@ -1117,7 +975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "522a047cac0958097ee71d047dd71cb84979fd2fa21c7a68fbe12736bef870a2"
 dependencies = [
  "futures 0.3.16",
- "hyper 0.13.10",
+ "hyper",
  "jsonrpc-core",
  "jsonrpc-server-utils",
  "log",
@@ -1138,7 +996,7 @@ dependencies = [
  "log",
  "parking_lot",
  "rand 0.7.3",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -1153,8 +1011,8 @@ dependencies = [
  "jsonrpc-core",
  "lazy_static",
  "log",
- "tokio 0.2.25",
- "tokio-util 0.3.1",
+ "tokio",
+ "tokio-util",
  "unicase",
 ]
 
@@ -1189,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.99"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "linked-hash-map"
@@ -1237,15 +1095,15 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memmap2"
@@ -1264,12 +1122,6 @@ checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mio"
@@ -1291,26 +1143,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
-dependencies = [
- "libc",
- "log",
- "miow 0.3.7",
- "ntapi",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "mio-named-pipes"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
- "mio 0.6.23",
+ "mio",
  "miow 0.3.7",
  "winapi 0.3.9",
 ]
@@ -1323,7 +1162,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio 0.6.23",
+ "mio",
 ]
 
 [[package]]
@@ -1345,24 +1184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1391,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
+checksum = "e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031"
 dependencies = [
  "bitflags",
  "cc",
@@ -1492,45 +1313,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opencl3"
-version = "0.2.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2362074823a6505fc03fe1729c2fd4bdf9668c70e0ecaf8de7d1799cd54b465"
+checksum = "f8862f86c2b3f757038243318edb55a47b1be7d46376fe6bdd9aedd1b0074902"
 dependencies = [
  "cl3",
  "libc",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -1582,12 +1370,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
-name = "percent-encoding"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-
-[[package]]
 name = "pest"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,12 +1415,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plotters"
@@ -1896,44 +1672,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
-dependencies = [
- "base64",
- "bytes 1.0.1",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "http",
- "http-body 0.4.3",
- "hyper 0.14.11",
- "hyper-tls",
- "ipnet",
- "js-sys",
- "lazy_static",
- "log",
- "mime",
- "native-tls",
- "percent-encoding 2.1.0",
- "pin-project-lite 0.2.7",
- "serde 1.0.127",
- "serde_urlencoded",
- "tokio 1.9.0",
- "tokio-native-tls",
- "url 2.2.2",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
 name = "rust-gpu-tools"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcf264eeb8cbea81e83cd5ed838b9ee51b0879a55896c000cf2d4161d509eac"
+checksum = "a300963e624abc34bf16490160380b83a2ee0fda7edf0cf5252f8328ad99c375"
 dependencies = [
  "dirs 2.0.2",
  "hex",
@@ -1993,16 +1735,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-dependencies = [
- "lazy_static",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "scheduler"
 version = "0.1.0"
 dependencies = [
@@ -2023,7 +1755,7 @@ dependencies = [
  "parking_lot",
  "priority-queue",
  "rand 0.8.4",
- "serde 1.0.127",
+ "serde 1.0.129",
  "sled",
  "sysinfo",
  "thiserror",
@@ -2037,29 +1769,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "security-framework"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -2108,9 +1817,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.127"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+checksum = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
 dependencies = [
  "serde_derive",
 ]
@@ -2129,19 +1838,19 @@ dependencies = [
 
 [[package]]
 name = "serde_cbor"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.127"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+checksum = "e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2156,19 +1865,7 @@ checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.127",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -2254,16 +1951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,9 +1964,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2371,7 +2058,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
 ]
 
@@ -2403,7 +2090,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "mio 0.6.23",
+ "mio",
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
@@ -2411,21 +2098,6 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "tokio-macros",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
-dependencies = [
- "autocfg",
- "bytes 1.0.1",
- "libc",
- "memchr",
- "mio 0.7.13",
- "pin-project-lite 0.2.7",
  "winapi 0.3.9",
 ]
 
@@ -2441,16 +2113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio 1.9.0",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,21 +2123,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.1.12",
- "tokio 0.2.25",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
-dependencies = [
- "bytes 1.0.1",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio",
 ]
 
 [[package]]
@@ -2484,7 +2132,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.127",
+ "serde 1.0.129",
 ]
 
 [[package]]
@@ -2530,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
@@ -2564,22 +2212,22 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
- "serde 1.0.127",
+ "serde 1.0.129",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
+checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
 dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
  "matchers",
  "regex",
- "serde 1.0.127",
+ "serde 1.0.129",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -2619,12 +2267,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"
@@ -2653,28 +2298,10 @@ version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 dependencies = [
- "idna 0.1.5",
+ "idna",
  "matches",
- "percent-encoding 1.0.1",
+ "percent-encoding",
 ]
-
-[[package]]
-name = "url"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
-dependencies = [
- "form_urlencoded",
- "idna 0.2.3",
- "matches",
- "percent-encoding 2.1.0",
-]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
@@ -2734,21 +2361,19 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
+checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.127",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
+checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2760,22 +2385,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
-dependencies = [
- "cfg-if 1.0.0",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
+checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2783,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
+checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2796,15 +2409,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
+checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
 
 [[package]]
 name = "web-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
+checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2852,15 +2465,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winreg"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
-dependencies = [
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "ws2_32-sys"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,10 +6,7 @@ edition = "2018"
 
 [dependencies]
 common = { path = "../common/" }
-futures = "0.3.15"
-jsonrpc-http-server = "17.1.0"
 nix = "0.22.0"
-reqwest = "0.11.4"
 scheduler = { path = "../scheduler/" }
 serde = { version = "1.0.126", features = ["serde_derive"] }
 tokio = { version = "0.2", features = ["time", "rt-threaded"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -17,8 +17,8 @@ fs2 = "0.4.3"
 thiserror = "1.0.26"
 jsonrpc-core = "17.1.0"
 jsonrpc-core-client = { version = "17.1.0", features = ["http"] }
-palaver = "0.2.8"
 once_cell = "1.8.0"
+dirs = "3.0.2"
 
 [dev-dependencies]
 criterion = "0.3.4"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -12,7 +12,7 @@ nix = "0.22.0"
 reqwest = "0.11.4"
 scheduler = { path = "../scheduler/" }
 serde = { version = "1.0.126", features = ["serde_derive"] }
-tokio = { version = "0.2", features = ["time"] }
+tokio = { version = "0.2", features = ["time", "rt-threaded"] }
 tracing = "0.1.26"
 tracing-futures = "0.2.5"
 chrono = "0.4.19"

--- a/client/benches/schedule_one_of.rs
+++ b/client/benches/schedule_one_of.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 
 use std::time::Duration;
 
-use client::{register, schedule_one_of, Error, ResourceAlloc, TaskFunc, TaskResult};
+use client::{Client, Error, ResourceAlloc, TaskFunc, TaskResult};
 use common::dummy_task_requirements;
 const NUM_ITERATIONS: usize = 100;
 
@@ -40,18 +40,14 @@ impl TaskFunc for Test {
 }
 
 fn call_schedule(b: &mut Bencher) {
-    let client = register::<Error>(None, None).unwrap();
+    let client = Client::register::<Error>().unwrap();
 
     let task_req = dummy_task_requirements();
     let mut test_func = Test::new(client.token.pid as _);
     b.iter(|| {
-        let _ = schedule_one_of(
-            client.clone(),
-            &mut test_func,
-            task_req.clone(),
-            Duration::from_secs(60),
-        )
-        .unwrap();
+        let _ = client
+            .schedule_one_of(&mut test_func, task_req.clone(), Duration::from_secs(60))
+            .unwrap();
     });
 }
 

--- a/client/scheduler.config.toml
+++ b/client/scheduler.config.toml
@@ -1,0 +1,25 @@
+[[tasks_settings]]
+task_type = "MerkleTree"
+devices = ["00:00", "00:01", "00:02"]
+timeout = 1500
+deadline = 1500
+
+[[tasks_settings]]
+task_type = "WinningPost"
+devices = ["00:02"]
+timeout = 15
+deadline = 15
+
+[[tasks_settings]]
+task_type = "WindowPost"
+devices = ["00:00", "00:01", "00:02"]
+timeout = 900
+deadline = 900
+
+[service]
+address = "127.0.0.1:5000"
+maintenance_interval = 2000
+shutdown_timeout = 300
+
+[time_settings]
+min_wait_time = 120

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     TaskFunctionPanics,
     #[error("ConnectionError: `{0}`")]
     ConnectionError(String),
+    #[error("ConfigError: `{0}`")]
+    ConfigError(String),
     #[error("Unknown error: `{0}`")]
     Other(String),
 }

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -21,12 +21,19 @@ pub enum Error {
     NoGpuResources,
     #[error("Unexpected panic in task function")]
     TaskFunctionPanics,
+    #[error("ConnectionError: `{0}`")]
+    ConnectionError(String),
     #[error("Unknown error: `{0}`")]
     Other(String),
 }
 
 impl From<RpcError> for Error {
     fn from(err: RpcError) -> Self {
-        Self::RpcError(err.to_string())
+        match &err {
+            RpcError::Other(ref e) if e.to_string().contains("tcp connect error") => {
+                Self::ConnectionError(e.to_string())
+            }
+            _ => Self::RpcError(err.to_string()),
+        }
     }
 }

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -1,5 +1,6 @@
 use std::io::Error as IoError;
 
+use jsonrpc_core_client::RpcError;
 use scheduler::Error as SchedulerError;
 
 #[derive(thiserror::Error, Debug)]
@@ -22,4 +23,10 @@ pub enum Error {
     TaskFunctionPanics,
     #[error("Unknown error: `{0}`")]
     Other(String),
+}
+
+impl From<RpcError> for Error {
+    fn from(err: RpcError) -> Self {
+        Self::RpcError(err.to_string())
+    }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::time::Duration;
 
 use tracing::{debug, error, trace, warn};
@@ -9,8 +10,8 @@ pub use common::{
     TaskRequirements, TaskResult, TaskType,
 };
 pub use error::Error;
-pub use rpc_client::{Client, RpcCaller};
-use scheduler::run_scheduler;
+pub use rpc_client::RpcCaller;
+use scheduler::{run_scheduler, Settings};
 pub use scheduler::{spawn_scheduler_with_handler, Error as SchedulerError};
 
 pub mod error;
@@ -60,322 +61,354 @@ pub fn abort(_client: ClientToken) -> Result<(), Error> {
     unimplemented!();
 }
 
-#[tracing::instrument(level = "info", skip(context))]
-pub fn register<E: From<Error>>(
-    client_name: Option<String>,
-    context: Option<String>,
-) -> Result<Client, E> {
-    let pid = palaver::thread::gettid();
-    let token = ClientToken {
-        pid,
-        name: client_name.unwrap_or_else(|| "".to_string()),
-    };
-    // TODO: Here we look for the config file and get the address from there as other params as
-    // well
-    Client::new(
-        &server_address(),
-        token,
-        context.unwrap_or_else(Default::default),
-    )
-    .map_err(E::from)
+#[derive(Clone)]
+pub struct Client {
+    pub address: String,
+    pub token: ClientToken,
+    /// Helper string that gives more context in logs messages
+    /// if it is not set a None value is the default
+    pub context: String,
+    pub(crate) rpc_caller: RpcCaller,
 }
 
-/// Schedules a task
-///
-/// The scheduler would pick up one of the resource requirements the client listed
-/// according to the current resource usage in terms of memory and priorities that this task and
-/// the ones already running have.
-///
-/// # Arguments:
-/// * `client` - The client identifier
-/// * `task_func` - The task functions object that implements [TaskFunc] trait
-/// * `req` - The task requirements, what is needed for executing this task. It also gives some
-/// information about execution times, deadlines and resource requirements. If __None__ the task
-/// would be executed immediately without the intervention of the scheduler service. Otherwise the
-/// task is scheduled on the resource that best fit the requirements. The task execution
-/// will be controlled by the scheduler service.
-/// * `timeout` - Indicates how much the client is able to wait for the task to be scheduled. It is
-/// possible that the client have to wait for resources to be freed when other task are done. If it expires and Error would be returned indicating it was
-/// the case.
-#[tracing::instrument(level = "info", skip(timeout, task_func, req, client), fields(pid = client.token.pid))]
-pub fn schedule_one_of<T, E: From<Error>>(
-    client: Client,
-    task_func: &mut dyn TaskFunc<Output = T, Error = E>,
-    mut req: TaskRequirements,
-    timeout: Duration,
-) -> Result<T, E> {
-    let address = server_address();
-
-    let timeout = match req.task_type {
-        Some(TaskType::WindowPost) => {
-            // modify the deadline only if it is empty
-            req.deadline
-                .get_or_insert(Deadline::from_secs(0, WINDOW_POST_END_DEADLINE));
-            timeout
-        }
-        Some(TaskType::WinningPost) => {
-            // modify the deadline only if it is empty
-            req.deadline
-                .get_or_insert(Deadline::from_secs(0, WINNING_POST_END_DEADLINE));
-            Duration::from_secs(WINNING_POST_TIMEOUT)
-        }
-        _ => timeout,
-    };
-
-    check_scheduler_service_or_launch(address)?;
-    let caller = client.connect()?;
-    let allocation = wait_allocation(&caller, req, timeout)?;
-    let result = execute_task(&caller, timeout, task_func, &allocation);
-    let _ = release(&caller);
-    result
-}
-
-pub fn execute_without_scheduler<T, E>(
-    task_func: &mut dyn TaskFunc<Output = T, Error = E>,
-) -> Result<T, E> {
-    task_func.init(None)?;
-    let mut cont = TaskResult::Continue;
-    while cont == TaskResult::Continue {
-        cont = task_func.task(None)?;
+impl fmt::Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Client")
+            .field("adress", &self.address)
+            .field("token", &self.token)
+            .field("context", &self.context)
+            .field("rpc_caller", &"http")
+            .finish()
     }
-    task_func.end(None)
 }
 
-#[tracing::instrument(level = "info", skip(client, timeout, task, alloc))]
-fn execute_task<'a, T, E: From<Error>>(
-    client: &RpcCaller,
-    timeout: Duration,
-    task: &mut dyn TaskFunc<Output = T, Error = E>,
-    alloc: &ResourceAlloc,
-) -> Result<T, E> {
-    use std::panic::{catch_unwind, AssertUnwindSafe};
+impl Client {
+    #[tracing::instrument(level = "info")]
+    pub fn register<E: From<Error>>() -> Result<Client, E> {
+        let pid = palaver::thread::gettid();
+        let token = ClientToken {
+            pid,
+            name: String::new(),
+        };
+        // TODO: Here we look for the config file and get the address from there as other params as
+        // well
+        Client::new(&server_address(), token).map_err(E::from)
+    }
+    /// Creates a client
+    /// `address` must be an address like: ip:port
+    fn new(address: &str, token: ClientToken) -> Result<Self, crate::Error> {
+        let base_url = format!("http://{}", address);
+        let rpc_caller = RpcCaller::new(&base_url.as_str())?;
+        let client = Self {
+            address: address.to_owned(),
+            token,
+            context: String::new(),
+            rpc_caller,
+        };
+        // start service if it is not running already
+        client.check_scheduler_service_or_launch()?;
+        Ok(client)
+    }
 
-    task.init(Some(alloc))?;
-    loop {
-        let preemptive_state = wait_preemptive(client, timeout)?;
+    pub fn set_name<T: ToString>(&mut self, name: T) {
+        self.token.name = name.to_string();
+    }
 
-        match preemptive_state {
-            PreemptionResponse::Wait => {}
-            PreemptionResponse::Execute => {
-                trace!(
-                    "client: {}:{} from: {} - Calling task function",
-                    client.inner.token.pid,
-                    client.inner.token.name,
-                    client.inner.context,
-                );
-                // try to handle possible panics
-                let result = catch_unwind(AssertUnwindSafe(|| task.task(Some(alloc))));
-                if let Err(_error) = result {
-                    let _ = release_preemptive(client);
-                    let _ = release(client);
-                    error!(
-                        "Client: {}:{} in {} panics",
-                        client.inner.token.pid, client.inner.token.name, client.inner.context,
+    pub fn set_context<T: ToString>(&mut self, context: T) {
+        self.context = context.to_string();
+    }
+}
+
+impl Client {
+    /// Schedules a task
+    ///
+    /// The scheduler would pick up one of the resource requirements the client listed
+    /// according to the current resource usage in terms of memory and priorities that this task and
+    /// the ones already running have.
+    ///
+    /// # Arguments:
+    /// * `client` - The client identifier
+    /// * `task_func` - The task functions object that implements [TaskFunc] trait
+    /// * `req` - The task requirements, what is needed for executing this task. It also gives some
+    /// information about execution times, deadlines and resource requirements. If __None__ the task
+    /// would be executed immediately without the intervention of the scheduler service. Otherwise the
+    /// task is scheduled on the resource that best fit the requirements. The task execution
+    /// will be controlled by the scheduler service.
+    /// * `timeout` - Indicates how much the client is able to wait for the task to be scheduled. It is
+    /// possible that the client have to wait for resources to be freed when other task are done. If it expires and Error would be returned indicating it was
+    /// the case.
+    #[tracing::instrument(level = "info", skip(self,timeout, task_func, req), fields(pid = self.token.pid))]
+    pub fn schedule_one_of<T, E: From<Error>>(
+        &self,
+        task_func: &mut dyn TaskFunc<Output = T, Error = E>,
+        mut req: TaskRequirements,
+        timeout: Duration,
+    ) -> Result<T, E> {
+        let timeout = match req.task_type {
+            Some(TaskType::WindowPost) => {
+                // modify the deadline only if it is empty
+                req.deadline
+                    .get_or_insert(Deadline::from_secs(0, WINDOW_POST_END_DEADLINE));
+                timeout
+            }
+            Some(TaskType::WinningPost) => {
+                // modify the deadline only if it is empty
+                req.deadline
+                    .get_or_insert(Deadline::from_secs(0, WINNING_POST_END_DEADLINE));
+                Duration::from_secs(WINNING_POST_TIMEOUT)
+            }
+            _ => timeout,
+        };
+
+        //self.check_scheduler_service_or_launch(address)?;
+        let allocation = self.wait_allocation(req, timeout)?;
+        let result = self.execute_task(timeout, task_func, &allocation);
+        let _ = self.release();
+        result
+    }
+
+    pub fn execute_without_scheduler<T, E>(
+        &self,
+        task_func: &mut dyn TaskFunc<Output = T, Error = E>,
+    ) -> Result<T, E> {
+        task_func.init(None)?;
+        let mut cont = TaskResult::Continue;
+        while cont == TaskResult::Continue {
+            cont = task_func.task(None)?;
+        }
+        task_func.end(None)
+    }
+
+    #[tracing::instrument(level = "info", skip(self, timeout, task, alloc))]
+    fn execute_task<'a, T, E: From<Error>>(
+        &self,
+        timeout: Duration,
+        task: &mut dyn TaskFunc<Output = T, Error = E>,
+        alloc: &ResourceAlloc,
+    ) -> Result<T, E> {
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+
+        task.init(Some(alloc))?;
+        loop {
+            let preemptive_state = self.wait_preemptive(timeout)?;
+
+            match preemptive_state {
+                PreemptionResponse::Wait => {}
+                PreemptionResponse::Execute => {
+                    trace!(
+                        "client: {}:{} from: {} - Calling task function",
+                        self.token.pid,
+                        self.token.name,
+                        self.context,
                     );
-                    // TODO: Look for ways to show the panic message. without propagating the panic
-                    return Err(E::from(Error::TaskFunctionPanics));
+                    // try to handle possible panics
+                    let result = catch_unwind(AssertUnwindSafe(|| task.task(Some(alloc))));
+                    if let Err(_error) = result {
+                        let _ = self.release_preemptive();
+                        let _ = self.release();
+                        error!(
+                            "Client: {}:{} in {} panics",
+                            self.token.pid, self.token.name, self.context,
+                        );
+                        // TODO: Look for ways to show the panic message. without propagating the panic
+                        return Err(E::from(Error::TaskFunctionPanics));
+                    }
+                    let cont = result.unwrap()?;
+                    trace!("Client {} task iteration completed", self.token.pid);
+                    self.release_preemptive()?;
+                    if cont == TaskResult::Done {
+                        break;
+                    }
                 }
-                let cont = result.unwrap()?;
-                trace!("Client {} task iteration completed", client.inner.token.pid);
-                release_preemptive(client)?;
-                if cont == TaskResult::Done {
-                    break;
+                PreemptionResponse::Abort => {
+                    warn!(
+                        "Client: {}:{} from: {} - aborted",
+                        self.token.pid, self.token.name, self.context,
+                    );
+                    return Err(E::from(Error::Aborted));
                 }
             }
-            PreemptionResponse::Abort => {
-                warn!(
-                    "Client: {}:{} from: {} - aborted",
-                    client.inner.token.pid, client.inner.token.name, client.inner.context
+        }
+
+        task.end(Some(alloc))
+    }
+
+    #[tracing::instrument(level = "info", skip(self, requirements, timeout), fields(pid = self.token.pid))]
+    fn wait_allocation(
+        &self,
+        requirements: TaskRequirements,
+        timeout: std::time::Duration,
+    ) -> Result<ResourceAlloc, Error> {
+        use std::time::Instant;
+        let start = Instant::now();
+        loop {
+            let alloc_state =
+                self.rpc_caller
+                    .wait_allocation(&self.token, &requirements, &self.context)?;
+            if let Some(alloc) = alloc_state {
+                debug!(
+                    "Client: {}:{} from: {} - got allocation {:?}",
+                    self.token.pid, self.token.name, self.context, alloc.devices,
                 );
-                return Err(E::from(Error::Aborted));
+                return Ok(alloc);
             }
-        }
-    }
-
-    task.end(Some(alloc))
-}
-
-#[tracing::instrument(level = "info", skip(client, requirements, timeout), fields(pid = client.inner.token.pid))]
-fn wait_allocation(
-    client: &RpcCaller,
-    requirements: TaskRequirements,
-    timeout: std::time::Duration,
-) -> Result<ResourceAlloc, Error> {
-    use std::time::Instant;
-    let start = Instant::now();
-    loop {
-        let alloc_state =
-            client.wait_allocation(requirements.clone(), client.inner.context.clone())?;
-        if let Some(alloc) = alloc_state {
-            debug!(
-                "Client: {}:{} from: {} - got allocation {:?}",
-                client.inner.token.pid,
-                client.inner.token.name,
-                client.inner.context,
-                alloc.devices,
-            );
-            return Ok(alloc);
-        }
-        if start.elapsed() > timeout {
-            return Err(Error::Timeout);
-        }
-        std::thread::sleep(Duration::from_millis(WAIT_ALLOCATION_DELAY));
-        // There are not available resources at this point so we have to try
-        // again.
-        warn!(
-            "Client: {} - Resources not available - waiting",
-            client.inner.token.pid
-        );
-    }
-}
-
-#[tracing::instrument(level = "info", skip(client, timeout), fields(pid = client.inner.token.pid))]
-fn wait_preemptive(client: &RpcCaller, timeout: Duration) -> Result<PreemptionResponse, Error> {
-    use std::time::Instant;
-    let start = Instant::now();
-    loop {
-        let response = client.wait_preemptive();
-        if let Ok(PreemptionResponse::Wait) = response {
             if start.elapsed() > timeout {
                 return Err(Error::Timeout);
             }
-            std::thread::sleep(Duration::from_millis(WAIT_PREEMPTIVE_DELAY));
-        } else {
-            return response;
+            std::thread::sleep(Duration::from_millis(WAIT_ALLOCATION_DELAY));
+            // There are not available resources at this point so we have to try
+            // again.
+            warn!(
+                "Client: {} - Resources not available - waiting",
+                self.token.pid
+            );
         }
     }
-}
 
-#[tracing::instrument(level = "info", skip(client), fields(pid = client.inner.token.pid))]
-fn release_preemptive(client: &RpcCaller) -> Result<(), Error> {
-    client.release_preemptive()
-}
-
-#[tracing::instrument(level = "info", skip(client), fields(pid = client.inner.token.pid))]
-fn release(client: &RpcCaller) -> Result<(), Error> {
-    client.release()
-}
-
-#[allow(dead_code)]
-#[tracing::instrument(level = "debug", skip(address))]
-fn launch_scheduler_process(address: String) -> Result<(), Error> {
-    use global_mutex::GlobalMutex;
-    use nix::unistd::{fork, ForkResult};
-
-    // check if there are resources to manage before trying to start the scheduler service
-    let devices = common::list_devices();
-    if devices.gpu_devices().is_empty() {
-        return Err(Error::NoGpuResources);
-    }
-
-    match unsafe { fork() } {
-        Ok(ForkResult::Parent { .. }) => {
-            // number of retries to check that the scheduler-service is running
-            let mut retries = START_SERVER_RETRIES;
-            std::thread::sleep(Duration::from_millis(START_SERVER_DELAY));
-            while let Err(e) = check_scheduler_service(address.clone()) {
-                // make the parent process wait for the service to run
-                warn!("service has not been started yet, trying again in 500 ms");
-                retries -= 1;
-                if retries == 0 {
-                    return Err(Error::Other(format!(
-                        "Can not start scheduler service: {}",
-                        e.to_string()
-                    )));
+    #[tracing::instrument(level = "info", skip(self, timeout), fields(pid = self.token.pid))]
+    fn wait_preemptive(&self, timeout: Duration) -> Result<PreemptionResponse, Error> {
+        use std::time::Instant;
+        let start = Instant::now();
+        loop {
+            let response = self.rpc_caller.wait_preemptive(&self.token);
+            if let Ok(PreemptionResponse::Wait) = response {
+                if start.elapsed() > timeout {
+                    return Err(Error::Timeout);
                 }
-                std::thread::sleep(Duration::from_millis(START_SERVER_DELAY));
+                std::thread::sleep(Duration::from_millis(WAIT_PREEMPTIVE_DELAY));
+            } else {
+                return response;
             }
-            Ok(())
         }
-        Ok(ForkResult::Child) => match GlobalMutex::try_lock() {
-            Ok(guard) => {
+    }
+
+    #[tracing::instrument(level = "info", skip(self), fields(pid = self.token.pid))]
+    fn release_preemptive(&self) -> Result<(), Error> {
+        self.rpc_caller.release_preemptive(&self.token)
+    }
+
+    #[tracing::instrument(level = "info", skip(self), fields(pid = self.token.pid))]
+    fn release(&self) -> Result<(), Error> {
+        self.rpc_caller.release(&self.token)
+    }
+
+    /// Helper function for creating a ResourceReq list
+    /// - Get the current allocations in the scheduler, push any resource that has not been allocated and use it as requirements
+    /// - If there are not available resources, which means all memory is used
+    /// it would list the raw devices information and use that as requirements.
+    //pub fn resources_as_requirements() -> Result<Vec<common::ResourceReq>, Error> {
+    //// Get the current devices state.
+    //// removing those that do not have available memory
+    //let mut resources = list_allocations()?;
+    //resources.retain(|_, memory| *memory > 0);
+
+    //// Push the devices that has no been allocated
+    //// or in case there are not available. Just get the current devices in the system and propose
+    //// them as a requirement
+    //common::list_devices().gpu_devices().iter().for_each(|dev| {
+    //let selector = dev.device_id();
+    //resources.entry(selector).or_insert_with(|| dev.memory());
+    //});
+
+    //// map to memory => quantity
+    //let mut reqs: HashMap<u64, usize> = HashMap::new();
+    //resources.into_iter().for_each(|(_, memory)| {
+    //let entry = reqs.entry(memory).or_insert(0);
+    //*entry += 1;
+    //});
+    //Ok(reqs
+    //.into_iter()
+    //.map(|(memory, quantity)| ResourceReq {
+    //resource: ResourceType::Gpu(ResourceMemory::Mem(memory)),
+    //quantity,
+    //preemptible: true, // by default the resource is preemptible assuming the task will perform more than 1 iteration
+    //})
+    //.collect::<Vec<_>>())
+    //}
+
+    /// Returns a tuple with the ID and available memory of devices being used
+    pub fn list_allocations(&self) -> Result<HashMap<DeviceId, u64>, Error> {
+        let res = self.rpc_caller.list_allocations()?;
+
+        Ok(res.into_iter().collect::<HashMap<DeviceId, u64>>())
+    }
+
+    #[tracing::instrument(level = "debug")]
+    fn check_scheduler_service_or_launch(&self) -> Result<(), Error> {
+        if self.check_scheduler_service().is_ok() {
+            Ok(())
+        } else {
+            println!("Starting service");
+            self.launch_scheduler_process()
+        }
+    }
+
+    #[tracing::instrument(level = "debug")]
+    fn check_scheduler_service(&self) -> Result<Pid, Error> {
+        let pid = self.rpc_caller.check_server()?;
+        debug!("Scheduler service running, PID: {}", pid);
+        Ok(pid)
+    }
+
+    #[allow(dead_code)]
+    #[tracing::instrument(level = "debug", skip(self))]
+    fn launch_scheduler_process(&self) -> Result<(), Error> {
+        use global_mutex::GlobalMutex;
+        use nix::unistd::{fork, ForkResult};
+
+        // check if there are resources to manage before trying to start the scheduler service
+        let devices = common::list_devices();
+        if devices.gpu_devices().is_empty() {
+            return Err(Error::NoGpuResources);
+        }
+
+        match unsafe { fork() } {
+            Ok(ForkResult::Parent { .. }) => {
+                // number of retries to check that the scheduler-service is running
                 let mut retries = START_SERVER_RETRIES;
-                while let Err(e) = run_scheduler(&address, devices.clone()) {
-                    error!(err = %e,"Got error trying to start the server");
+                std::thread::sleep(Duration::from_millis(START_SERVER_DELAY));
+                while let Err(e) = self.check_scheduler_service() {
                     retries -= 1;
                     if retries == 0 {
-                        return Err(Error::Other(format!(
-                            "Can not start scheduler service: {}",
-                            e.to_string()
-                        )));
+                        error!(err = %e, "Failed starting scheduler service");
+                        return Err(e);
                     }
+                    std::thread::sleep(Duration::from_millis(START_SERVER_DELAY));
                 }
-                drop(guard);
                 Ok(())
             }
-            Err(e) => {
-                error!(err = %e,"Error acquiring lock");
-                debug!("another process started the scheduler - exiting");
-                Err(e)
-            }
-        },
-        Err(e) => Err(Error::Other(e.to_string())),
-    }
-}
-
-/// Helper function for creating a ResourceReq list
-/// - Get the current allocations in the scheduler, push any resource that has not been allocated and use it as requirements
-/// - If there are not available resources, which means all memory is used
-/// it would list the raw devices information and use that as requirements.
-pub fn resources_as_requirements() -> Result<Vec<common::ResourceReq>, Error> {
-    // Get the current devices state.
-    // removing those that do not have available memory
-    let mut resources = list_allocations()?;
-    resources.retain(|_, memory| *memory > 0);
-
-    // Push the devices that has no been allocated
-    // or in case there are not available. Just get the current devices in the system and propose
-    // them as a requirement
-    common::list_devices().gpu_devices().iter().for_each(|dev| {
-        let selector = dev.device_id();
-        resources.entry(selector).or_insert_with(|| dev.memory());
-    });
-
-    // map to memory => quantity
-    let mut reqs: HashMap<u64, usize> = HashMap::new();
-    resources.into_iter().for_each(|(_, memory)| {
-        let entry = reqs.entry(memory).or_insert(0);
-        *entry += 1;
-    });
-    Ok(reqs
-        .into_iter()
-        .map(|(memory, quantity)| ResourceReq {
-            resource: ResourceType::Gpu(ResourceMemory::Mem(memory)),
-            quantity,
-            preemptible: true, // by default the resource is preemptible assuming the task will perform more than 1 iteration
-        })
-        .collect::<Vec<_>>())
-}
-
-/// Returns a tuple with the ID and available memory of devices being used
-pub fn list_allocations() -> Result<HashMap<DeviceId, u64>, Error> {
-    check_scheduler_service_or_launch(server_address())?;
-    let client = Client::new(&server_address(), Default::default(), Default::default())?;
-    let client = client.connect()?;
-    let res = client.list_allocations()?;
-
-    Ok(res.into_iter().collect::<HashMap<DeviceId, u64>>())
-}
-
-#[tracing::instrument(level = "debug")]
-fn check_scheduler_service_or_launch(address: String) -> Result<(), Error> {
-    if check_scheduler_service(address.clone()).is_ok() {
-        Ok(())
-    } else {
-        warn!("Scheduler service not running - trying to launch it");
-        launch_scheduler_process(address)
+            Ok(ForkResult::Child) => match GlobalMutex::try_lock() {
+                Ok(guard) => {
+                    let mut retries = START_SERVER_RETRIES;
+                    while let Err(e) = run_scheduler(&self.address, devices.clone()) {
+                        retries -= 1;
+                        println!("RETRIES {}", retries);
+                        if retries == 0 {
+                            error!(err = %e, "Failed starting scheduler service");
+                            return Err(Error::Scheduler(e));
+                        }
+                    }
+                    drop(guard);
+                    Ok(())
+                }
+                Err(e) => {
+                    error!(err = %e,"Error acquiring lock");
+                    debug!("another process started the scheduler - exiting");
+                    Err(e)
+                }
+            },
+            Err(e) => Err(Error::Other(e.to_string())),
+        }
     }
 }
 
 #[tracing::instrument(level = "debug")]
 fn check_scheduler_service(address: String) -> Result<Pid, Error> {
-    let client = Client::new(&address, Default::default(), Default::default())?;
-    let client = client.connect()?;
-    let pid = client.check_server()?;
+    let client = Client::register::<Error>()?;
+    let pid = client.rpc_caller.check_server()?;
     debug!("Scheduler service running, PID: {}", pid);
     Ok(pid)
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -427,17 +460,12 @@ mod tests {
 
     #[test]
     fn calls_scheduler_one_process() {
-        let token = register::<Error>(None, None).unwrap();
+        let client = Client::register::<Error>().unwrap();
 
         let devices = common::list_devices();
         let handle = scheduler::spawn_scheduler_with_handler(&server_address(), devices).unwrap();
 
-        let res = schedule_one_of(
-            token,
-            &mut TaskTest,
-            task_requirements(),
-            Default::default(),
-        );
+        let res = client.schedule_one_of(&mut TaskTest, task_requirements(), Default::default());
         // Accept just this type of error
         if let Err(e) = res {
             assert!(matches!(e, Error::Timeout));
@@ -449,7 +477,7 @@ mod tests {
     fn release_test() {
         // This test only check communication and well formed param parsing
         let address = server_address();
-        let client = Client::new(&address, Default::default(), Default::default()).unwrap();
+        let client = Client::register::<Error>().unwrap();
         let devices = common::list_devices();
         let handle = scheduler::spawn_scheduler_with_handler(&address, devices).unwrap();
         let _res_req = ResourceReq {
@@ -458,7 +486,6 @@ mod tests {
             preemptible: true,
         };
 
-        let client = client.connect().unwrap();
         let res = client.release();
         handle.close();
 
@@ -468,7 +495,7 @@ mod tests {
     #[test]
     fn test_panic_handler() {
         let address = server_address();
-        let client = Client::new(&address, Default::default(), Default::default()).unwrap();
+        let client = Client::register::<Error>().unwrap();
         let devices = common::list_devices();
         let handle = scheduler::spawn_scheduler_with_handler(&address, devices).unwrap();
         let _res_req = ResourceReq {
@@ -477,8 +504,7 @@ mod tests {
             preemptible: true,
         };
 
-        let res = schedule_one_of(
-            client,
+        let res = client.schedule_one_of(
             &mut TaskTestPanic,
             task_requirements(),
             Duration::from_secs(60),

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -93,7 +93,7 @@ impl Client {
     /// `address` must be an address like: ip:port
     fn new(token: ClientToken, settings: Settings) -> Result<Self, crate::Error> {
         let base_url = format!("http://{}", settings.service.address);
-        let rpc_caller = RpcCaller::new(&base_url.as_str())?;
+        let rpc_caller = RpcCaller::new(base_url.as_str())?;
         let client = Self {
             token,
             context: String::new(),
@@ -433,11 +433,6 @@ mod tests {
         let client = Client::register_with_settings::<Error>(settings.clone()).unwrap();
         let devices = common::list_devices();
         let handle = spawn_scheduler_with_handler(settings, "/tmp/release/", devices).unwrap();
-        let _res_req = ResourceReq {
-            resource: common::ResourceType::Gpu(ResourceMemory::Mem(2)),
-            quantity: 1,
-            preemptible: true,
-        };
 
         let res = client.release();
         handle.close();
@@ -453,11 +448,6 @@ mod tests {
         let devices = common::list_devices();
         let handle =
             spawn_scheduler_with_handler(settings, "/tmp/panic_handler/", devices).unwrap();
-        let _res_req = ResourceReq {
-            resource: common::ResourceType::Gpu(ResourceMemory::Mem(2)),
-            quantity: 1,
-            preemptible: true,
-        };
 
         let res = client.schedule_one_of(
             &mut TaskTestPanic,

--- a/client/src/rpc_client.rs
+++ b/client/src/rpc_client.rs
@@ -1,5 +1,5 @@
 use jsonrpc_core_client::transports::http::connect;
-use jsonrpc_core_client::{RpcChannel, RpcResult, TypedClient};
+use jsonrpc_core_client::{RpcChannel, TypedClient};
 use tokio::runtime::Runtime;
 
 use super::Error as ClientError;
@@ -9,8 +9,8 @@ use scheduler::Error;
 use once_cell::sync::OnceCell;
 
 fn get_runtime() -> &'static Runtime {
-    static INSTANCE: OnceCell<Runtime> = OnceCell::new();
-    INSTANCE.get_or_init(|| Runtime::new().expect("Error creating tokio runtime"))
+    static RUNTIME: OnceCell<Runtime> = OnceCell::new();
+    RUNTIME.get_or_init(|| Runtime::new().expect("Error creating tokio runtime"))
 }
 
 #[derive(Debug, Clone)]
@@ -49,9 +49,7 @@ impl Client {
 
     pub fn connect(self) -> Result<RpcCaller, ClientError> {
         let handle = get_runtime().handle();
-        let inner = handle
-            .block_on(async { connect(self.base_url.as_str()).await })
-            .map_err(|e| ClientError::RpcError(e.to_string()))?;
+        let inner = handle.block_on(async { connect(self.base_url.as_str()).await })?;
         let handler = RpcHandler(inner);
         Ok(RpcCaller {
             handler,
@@ -60,83 +58,97 @@ impl Client {
     }
 }
 impl RpcCaller {
-    pub fn wait_preemptive(&self) -> RpcResult<Result<PreemptionResponse, Error>> {
-        let handle = get_runtime().handle();
-        handle.block_on(async {
-            self.handler
-                .0
-                .call_method(
-                    "wait_preemptive",
-                    "Result<PreemptionResponse, Error>",
-                    (self.inner.token.clone(),),
-                )
-                .await
-        })
+    pub fn wait_preemptive(&self) -> Result<PreemptionResponse, ClientError> {
+        get_runtime()
+            .handle()
+            .block_on(async {
+                self.handler
+                    .0
+                    .call_method::<_, Result<PreemptionResponse, Error>>(
+                        "wait_preemptive",
+                        "Result<PreemptionResponse, Error>",
+                        (self.inner.token.clone(),),
+                    )
+                    .await
+            })?
+            .map_err(ClientError::Scheduler)
     }
 
-    pub fn check_server(&self) -> RpcResult<Pid> {
+    pub fn check_server(&self) -> Result<Pid, ClientError> {
         let handle = get_runtime().handle();
-        handle.block_on(async {
+        Ok(handle.block_on(async {
             self.handler
                 .0
                 .call_method("service_status", "Pid", ())
                 .await
-        })
+        })?)
     }
 
-    pub fn list_allocations(&self) -> RpcResult<Result<Vec<(DeviceId, u64)>, Error>> {
-        let handle = get_runtime().handle();
-        handle.block_on(async {
-            self.handler
-                .0
-                .call_method(
-                    "list_allocations",
-                    "Result<Vec<(DeviceId, u64)>, Error>",
-                    (),
-                )
-                .await
-        })
+    pub fn list_allocations(&self) -> Result<Vec<(DeviceId, u64)>, ClientError> {
+        get_runtime()
+            .handle()
+            .block_on(async {
+                self.handler
+                    .0
+                    .call_method::<_, Result<Vec<(DeviceId, u64)>, Error>>(
+                        "list_allocations",
+                        "Result<Vec<(DeviceId, u64)>, Error>",
+                        (),
+                    )
+                    .await
+            })?
+            .map_err(ClientError::Scheduler)
     }
 
     pub fn wait_allocation(
         &self,
         task: TaskRequirements,
         job_context: String,
-    ) -> RpcResult<Result<Option<ResourceAlloc>, Error>> {
-        let handle = get_runtime().handle();
-        handle.block_on(async {
-            self.handler
-                .0
-                .call_method(
-                    "wait_allocation",
-                    "Result<Option<ResourceAlloc>, Error>>",
-                    (self.inner.token.clone(), task, job_context),
-                )
-                .await
-        })
+    ) -> Result<Option<ResourceAlloc>, ClientError> {
+        get_runtime()
+            .handle()
+            .block_on(async {
+                self.handler
+                    .0
+                    .call_method::<_, Result<Option<ResourceAlloc>, Error>>(
+                        "wait_allocation",
+                        "Result<Option<ResourceAlloc>, Error>>",
+                        (self.inner.token.clone(), task, job_context),
+                    )
+                    .await
+            })?
+            .map_err(ClientError::Scheduler)
     }
 
-    pub fn release(&self) -> RpcResult<Result<(), Error>> {
-        let handle = get_runtime().handle();
-        handle.block_on(async {
-            self.handler
-                .0
-                .call_method("release", "Result<(), Error>>", (self.inner.token.clone(),))
-                .await
-        })
+    pub fn release(&self) -> Result<(), ClientError> {
+        get_runtime()
+            .handle()
+            .block_on(async {
+                self.handler
+                    .0
+                    .call_method::<_, Result<(), Error>>(
+                        "release",
+                        "Result<(), Error>>",
+                        (self.inner.token.clone(),),
+                    )
+                    .await
+            })?
+            .map_err(ClientError::Scheduler)
     }
 
-    pub fn release_preemptive(&self) -> RpcResult<Result<(), Error>> {
-        let handle = get_runtime().handle();
-        handle.block_on(async {
-            self.handler
-                .0
-                .call_method(
-                    "release_preemptive",
-                    "Result<(), Error>>",
-                    (self.inner.token.clone(),),
-                )
-                .await
-        })
+    pub fn release_preemptive(&self) -> Result<(), ClientError> {
+        get_runtime()
+            .handle()
+            .block_on(async {
+                self.handler
+                    .0
+                    .call_method::<_, Result<(), Error>>(
+                        "release_preemptive",
+                        "Result<(), Error>>",
+                        (self.inner.token.clone(),),
+                    )
+                    .await
+            })?
+            .map_err(ClientError::Scheduler)
     }
 }

--- a/client/tests/test.rs
+++ b/client/tests/test.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::UdpSocket;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -88,10 +89,11 @@ fn test_schedule() {
     let devices_state = Arc::new(DevicesState(hash_map));
 
     let mut settings = Settings::new("/tmp/test.config.toml").unwrap();
-    settings.service.address = "127.0.0.1:4000".to_owned();
+    let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+    settings.service.address = format!("{}", socket.local_addr().unwrap());
     let handler =
         spawn_scheduler_with_handler(settings.clone(), "/tmp/schedule/", devices).unwrap();
-    //std::thread::sleep(Duration::from_millis(500));
+    std::thread::sleep(Duration::from_millis(500));
 
     let mut joiner = vec![];
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,3 +10,4 @@ num_cpus = "1.13.0"
 rust-gpu-tools = { version = "0.4.0"}
 serde = { version = "1.0.120", features = ["serde_derive"] }
 tracing = "0.1.25"
+palaver = "0.2.8"

--- a/common/src/client.rs
+++ b/common/src/client.rs
@@ -9,10 +9,9 @@ pub struct ClientToken {
 impl Default for ClientToken {
     fn default() -> Self {
         let pid = palaver::thread::gettid();
-        let token = ClientToken {
+        ClientToken {
             pid,
             name: String::new(),
-        };
-        token
+        }
     }
 }

--- a/common/src/client.rs
+++ b/common/src/client.rs
@@ -1,7 +1,18 @@
 pub type Pid = u64;
 
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize, Hash, Eq, PartialEq)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Hash, Eq, PartialEq)]
 pub struct ClientToken {
     pub pid: Pid,
     pub name: String,
+}
+
+impl Default for ClientToken {
+    fn default() -> Self {
+        let pid = palaver::thread::gettid();
+        let token = ClientToken {
+            pid,
+            name: String::new(),
+        };
+        token
+    }
 }

--- a/scheduler.config.toml
+++ b/scheduler.config.toml
@@ -1,18 +1,18 @@
 [[tasks_settings]]
 task_type = "MerkleTree"
-devices = ["00:00", "00:01", "00:02"]
+devices = ["cd41e33e-91de-f0ff-e764-b00297783841", "46abccd6-022e-b783-572d-833f7104d05f"]
 timeout = 1500
 deadline = 1500
 
 [[tasks_settings]]
 task_type = "WinningPost"
-devices = ["00:02"]
+devices = ["cd41e33e-91de-f0ff-e764-b00297783841", "46abccd6-022e-b783-572d-833f7104d05f"]
 timeout = 15
 deadline = 15
 
 [[tasks_settings]]
 task_type = "WindowPost"
-devices = ["00:00", "00:01", "00:02"]
+devices = ["cd41e33e-91de-f0ff-e764-b00297783841", "46abccd6-022e-b783-572d-833f7104d05f"]
 timeout = 900
 deadline = 900
 

--- a/scheduler/src/config.rs
+++ b/scheduler/src/config.rs
@@ -18,12 +18,23 @@ const MAINTENANCE_INTERVAL: u64 = 2000;
 const SHUTDOWN_TIMEOUT: u64 = 300;
 
 const MIN_WAIT_TIME: u64 = 120;
+// default deadline for merkeltree tasks
+const DEFAULT_DEADLINE: u64 = 1500;
+// Constant that defines the winning_post deadline and timeout
+const WINNING_POST_DEADLINE: u64 = 15;
+// Constant that defines the window_post deadline and timeout
+const WINDOW_POST_DEADLINE: u64 = 900;
+
+// Server address
+const SERVER_ADDRESS: &str = "127.0.0.1:5000";
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Task {
-    devices: Vec<DeviceId>,
     #[serde(deserialize_with = "TaskType::deserialize_with")]
-    task_type: TaskType,
+    pub task_type: TaskType,
+    pub devices: Vec<DeviceId>,
+    pub timeout: u64,
+    pub deadline: u64,
 }
 
 impl Task {
@@ -38,7 +49,7 @@ impl Task {
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 pub struct Service {
-    address: String,
+    pub address: String,
     /// interval in milliseconds. if present in the configuration file, creates a thread that performs some maintenance
     /// operations such as removing tasks that no longer exist in the system or automatic shutdown
     /// if there are not more tasks or requests.
@@ -70,7 +81,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         let service = Service {
-            address: "127.0.0.1:5000".to_string(),
+            address: SERVER_ADDRESS.to_string(),
             maintenance_interval: Some(MAINTENANCE_INTERVAL),
             shutdown_timeout: Some(SHUTDOWN_TIMEOUT),
         };
@@ -84,23 +95,24 @@ impl Default for Settings {
             .iter()
             .map(|d| d.device_id())
             .collect::<Vec<_>>();
-        let task = Task {
-            devices: all_devices.clone(),
-            task_type: TaskType::MerkleTree,
-        };
-        // create a setting with 3 task description
+        // create a setting with 3 tasks description
         let tasks_settings = (0..3)
             .map(|i| {
-                let mut task_i = task.clone();
-                task_i.task_type = match i {
-                    1 => TaskType::WindowPost,
-                    2 => TaskType::WinningPost,
-                    _ => TaskType::MerkleTree,
+                let (task_type, deadline) = match i {
+                    1 => (TaskType::WinningPost, WINNING_POST_DEADLINE),
+                    2 => (TaskType::WindowPost, WINDOW_POST_DEADLINE),
+                    _ => (TaskType::MerkleTree, DEFAULT_DEADLINE),
                 };
-                if task_i.task_type == TaskType::WinningPost && cfg!(dummy_devices) {
-                    task_i.devices = [all_devices[2].clone()].to_vec();
+                let mut task = Task {
+                    task_type,
+                    devices: all_devices.clone(),
+                    timeout: deadline,
+                    deadline,
+                };
+                if task.task_type == TaskType::WinningPost && cfg!(dummy_devices) {
+                    task.devices = [all_devices[2].clone()].to_vec();
                 }
-                task_i
+                task
             })
             .collect::<Vec<_>>();
 
@@ -113,7 +125,7 @@ impl Default for Settings {
 }
 
 impl Settings {
-    pub(crate) fn new<P: AsRef<Path>>(path: P) -> Result<Self, config::ConfigError> {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, config::ConfigError> {
         if path.as_ref().exists() {
             let mut s = Config::new();
             s.merge(File::with_name(path.as_ref().to_str().ok_or_else(

--- a/scheduler/src/db.rs
+++ b/scheduler/src/db.rs
@@ -12,6 +12,15 @@ pub struct Database {
 
 impl Database {
     pub fn open<P: AsRef<Path>>(path: P, temporary: bool) -> Result<Self> {
+        if !path.as_ref().exists() {
+            std::fs::create_dir_all(&path).map_err(|e| {
+                Error::Database(format!(
+                    "cannot create database in {:?} err: {}",
+                    path.as_ref(),
+                    e.to_string()
+                ))
+            })?;
+        }
         let config = Config::default()
             .path(path)
             .temporary(temporary)

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -66,7 +66,7 @@ pub fn spawn_scheduler_with_handler<P: AsRef<Path>>(
     let handler = scheduler::Scheduler::new(settings.clone(), devices, None, db)?;
     let server = Server::new(handler);
 
-    Ok(spawn_service(server, settings)?)
+    spawn_service(server, settings)
 }
 
 fn spawn_service<H: Handler>(server: Server<H>, settings: Settings) -> Result<CloseHandle> {

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -1,4 +1,4 @@
-use tracing::{error, warn};
+use tracing::warn;
 
 mod config;
 mod db;
@@ -25,68 +25,29 @@ use crate::db::Database;
 use jsonrpc_http_server::jsonrpc_core::IoHandler;
 use jsonrpc_http_server::CloseHandle;
 use jsonrpc_http_server::ServerBuilder;
-use std::path::PathBuf;
+use std::path::Path;
 
 use crossbeam::channel::bounded;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-const SCHEDULER_DB_NAME: &str = "scheduler_db";
-const SCHEDULER_CONFIG_NAME: &str = "scheduler.toml";
-const TEST_DB_NAME: &str = "scheduler_test_db";
-const TEST_CONFIG_NAME: &str = "scheduler_test.toml";
-
-pub(crate) fn get_config_path() -> Result<PathBuf> {
-    let path = if let Ok(val) = std::env::var("SCHEDULER_CONFIG_PATH") {
-        let path: PathBuf = val.into();
-        path
-    } else {
-        let mut path =
-            dirs::config_dir().ok_or_else(|| Error::Other("Unsupported platform".to_string()))?;
-        path.push("filecoin/");
-        path
-    };
-    // check that the dirs exist otherwise create them if possible
-    if !path.is_dir() {
-        std::fs::create_dir_all(&path)
-            .map_err(|e| Error::Other(format!("cannot create config dir {}", e.to_string())))?;
-    }
-    Ok(path)
-}
-
 /// Starts a json-rpc server listening to *addr*
-#[tracing::instrument(level = "debug", skip(devices))]
-pub fn run_scheduler(address: &str, devices: common::Devices) -> Result<()> {
-    let mut path = get_config_path()?;
-    path.push(SCHEDULER_CONFIG_NAME);
-    let settings = Settings::new(path).map_err(|e| {
-        error!(err = %e, "Error reading config file");
-        Error::InvalidConfig(e.to_string())
-    })?;
+#[tracing::instrument(level = "debug", skip(devices, settings, database_path))]
+pub fn run_scheduler<P: AsRef<Path>>(
+    settings: Settings,
+    database_path: P,
+    devices: common::Devices,
+) -> Result<()> {
     let maintenance_interval = settings.service.maintenance_interval;
     let (shutdown_tx, shutdown_rx) = bounded(0);
-    let mut path = crate::get_config_path()?;
-    path.push(SCHEDULER_DB_NAME);
-    let db = Database::open(path, false)?;
-    let handler = scheduler::Scheduler::new(settings, devices, Some(shutdown_tx), db)?;
+    let db = Database::open(database_path, false)?;
+    let handler = scheduler::Scheduler::new(settings.clone(), devices, Some(shutdown_tx), db)?;
     let server = Server::new(handler);
     if let Some(tick) = maintenance_interval {
         server.start_maintenance_thread(tick);
     }
-    let mut io = IoHandler::new();
 
-    let address: SocketAddr = address.parse().map_err(|_| Error::InvalidAddress)?;
-    io.extend_with(server.to_delegate());
-
-    let server = ServerBuilder::new(io)
-        .threads(num_cpus::get())
-        .start_http(&address)
-        .map_err(|e| Error::ConnectionError(e.to_string()))?;
-
-    let close_handle = server.close_handle();
-    std::thread::spawn(move || {
-        server.wait();
-    });
+    let close_handle = spawn_service(server, settings)?;
 
     let _ = shutdown_rx.recv().unwrap();
     close_handle.close();
@@ -94,27 +55,28 @@ pub fn run_scheduler(address: &str, devices: common::Devices) -> Result<()> {
     Ok(())
 }
 
-#[tracing::instrument(level = "debug", skip(devices))]
+#[tracing::instrument(level = "debug", skip(devices, settings, database_path))]
 // To be use for testing purposes
-pub fn spawn_scheduler_with_handler(
-    address: &str,
+pub fn spawn_scheduler_with_handler<P: AsRef<Path>>(
+    settings: Settings,
+    database_path: P,
     devices: common::Devices,
 ) -> Result<CloseHandle> {
-    let mut path = PathBuf::new();
-    path.push("/tmp");
-    path.push(TEST_CONFIG_NAME);
-    let settings = Settings::new(path.clone()).map_err(|e| {
-        error!(err = %e, "Error reading config file");
-        Error::InvalidConfig(e.to_string())
-    })?;
-    path.pop();
-    path.push(TEST_DB_NAME);
-    let db = Database::open(path, true)?;
-    let handler = scheduler::Scheduler::new(settings, devices, None, db)?;
+    let db = Database::open(database_path, true)?;
+    let handler = scheduler::Scheduler::new(settings.clone(), devices, None, db)?;
     let server = Server::new(handler);
-    let mut io = IoHandler::new();
 
-    let address: SocketAddr = address.parse().map_err(|_| Error::InvalidAddress)?;
+    Ok(spawn_service(server, settings)?)
+}
+
+fn spawn_service<H: Handler>(server: Server<H>, settings: Settings) -> Result<CloseHandle> {
+    let address: SocketAddr = settings
+        .service
+        .address
+        .parse()
+        .map_err(|_| Error::InvalidAddress)?;
+
+    let mut io = IoHandler::new();
     io.extend_with(server.to_delegate());
 
     let server = ServerBuilder::new(io)
@@ -122,7 +84,6 @@ pub fn spawn_scheduler_with_handler(
         .start_http(&address)
         .map_err(|e| Error::ConnectionError(e.to_string()))?;
     let close_handle = server.close_handle();
-
     std::thread::spawn(move || {
         server.wait();
     });

--- a/scheduler/src/solvers/greedy.rs
+++ b/scheduler/src/solvers/greedy.rs
@@ -102,7 +102,7 @@ impl Solver for GreedySolver {
     fn solve_job_schedule(
         &mut self,
         current_state: &HashMap<Pid, TaskState>,
-        _scheduler_settings: &Settings,
+        settings: &Settings,
     ) -> Result<VecDeque<Pid>> {
         // Criterion A: Use task deadline as a priority indicator. The sooner the deadline the higher
         //      the priority
@@ -114,10 +114,18 @@ impl Solver for GreedySolver {
 
         // iterate our tasks for making the triplet pushing it into the queue
         for (job_id, state) in current_state.iter() {
-            // get the jobs deadline or fake a new one.
-            let deadline = state.requirements.deadline.map_or(u64::MAX, |d| {
-                d.as_duration().map(|d| d.as_secs()).unwrap_or(u64::MAX)
-            });
+            // get the jobs deadline according to task_type.
+            let deadline = settings
+                .tasks_settings
+                .iter()
+                .find(|task| Some(task.task_type) == state.requirements.task_type)
+                .map(|task| task.deadline)
+                .unwrap_or_else(|| {
+                    state.requirements.deadline.map_or(u64::MAX, |d| {
+                        d.as_duration().map(|d| d.as_secs()).unwrap_or(u64::MAX)
+                    })
+                });
+
             let conditions = (Reverse(deadline), Reverse(state.creation_time));
             priority_queue.push(job_id, conditions);
         }


### PR DESCRIPTION
This add many changes:
- Make the client runtime multi-threaded so it can handle multiple requests in parallel(the performance improved a bit)
- Simplify the code by improving the jsonrpc's error handling
- and rustify the client library, now we have a client struct with methods like:
```rust
let mut client = Client::register().unwrap();
client.set_context(format!("client in {}:{}", file!(), line!());
...
client.schedule_one_of(..).unwrap()
```
this allows us to have a sort of context across all functions in the client like Settings
- Remove the hardcoded timeouts and deadlines for tasks according to their types, moving them to the configuration file, clients now have a settings file that is read when created. 
- The solver uses now the Settings to get the task's deadline in case the task type is defined, otherwise, it uses the deadline that comes in the client request(TaskRequirements).
- Make minor changes to the server initialization API which now takes in a settings param instead of a plain address, this allows us to ensure that clients and the scheduler service use the same address as define in the service's configuration file.
- Update tests, which use the Socket type to retrieve a port that is not in use for the test
- Add a default configuration file in the repo as an example.
- Other minor changes
