### PR TITLE
Add cuda/opencl features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "cl3"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68fdb522345cabcdd77098487d15632dd39e79ec50ccdc81073bf534b55b3da7"
+checksum = "a120623848b1af3824734f4f7d8e60e43b9c0cfe86f179a337e383e47234997a"
 dependencies = [
  "cl-sys",
  "libc",
@@ -410,6 +410,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuda-config"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "cuda-driver-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4c552cc0de854877d80bcd1f11db75d42be32962d72a6799b88dcca88fffbd"
+dependencies = [
+ "cuda-config",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,6 +505,18 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fil-rustacuda"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6313e2871ba9705f4151bb60d96b6f43e7444ed82918ba5fb99fbd448e82c34d"
+dependencies = [
+ "bitflags",
+ "cuda-driver-sys",
+ "rustacuda_core",
+ "rustacuda_derive",
+]
 
 [[package]]
 name = "fnv"
@@ -632,19 +662,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d9279ca822891c1a4dae06d185612cf8fc6acfe5dff37781b41297811b12ee"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +710,12 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
@@ -1073,17 +1096,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "loom"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2111607c723d7857e0d8299d5ce7a0bf4b844d3e44f8de136b13da513eaf8fc4"
-dependencies = [
- "cfg-if 1.0.0",
- "generator",
- "scoped-tls",
 ]
 
 [[package]]
@@ -1684,11 +1696,11 @@ dependencies = [
 
 [[package]]
 name = "rust-gpu-tools"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a300963e624abc34bf16490160380b83a2ee0fda7edf0cf5252f8328ad99c375"
+version = "0.4.3"
+source = "git+https://github.com/filecoin-project/rust-gpu-tools?branch=master#705641f36bedff317c30f1608594ad03f082d7eb"
 dependencies = [
  "dirs 2.0.2",
+ "fil-rustacuda",
  "hex",
  "lazy_static",
  "log",
@@ -1702,6 +1714,23 @@ name = "rust-ini"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
+
+[[package]]
+name = "rustacuda_core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3858b08976dc2f860c5efbbb48cdcb0d4fafca92a6ac0898465af16c0dbe848"
+
+[[package]]
+name = "rustacuda_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ce8670a1a1d0fc2514a3b846dacdb65646f9bd494b6674cfacbb4ce430bd7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "rustc_version"
@@ -1729,12 +1758,6 @@ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver 1.0.4",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
@@ -1765,7 +1788,6 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-derive",
  "jsonrpc-http-server",
- "loom",
  "num_cpus",
  "once_cell",
  "palaver",
@@ -1781,12 +1803,6 @@ dependencies = [
  "tracing",
  "tracing-futures",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 nix = "0.22.0"
-scheduler = { path = "../scheduler/" }
+scheduler = { path = "../scheduler/", optional = true}
 serde = { version = "1.0.126", features = ["serde_derive"] }
 tokio_02 = { package = "tokio", version = "0.2", features = ["time", "rt-threaded"]}
 tracing = "0.1.26"
@@ -25,6 +25,11 @@ ipmpsc = "0.5.1"
 rand = "0.8.4"
 tracing-appender = "0.1.2"
 tracing-subscriber = { version = "0.2.19", default-features = true }
+
+[features]
+default = ["opencl"]
+cuda = ["scheduler/cuda"]
+opencl = ["scheduler/opencl"]
 
 [[bench]]
 name = "schedule_one_of"

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -26,7 +26,6 @@ num_cpus = "1.13.0"
 sled = { version = "0.34.6" }
 bincode = "1.3.3"
 once_cell = "1.8.0"
-#rust-gpu-tools = { version = "0.4.0"}
 rust-gpu-tools = { git = "https://github.com/filecoin-project/rust-gpu-tools", branch = "master", default-features = false}
 
 

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -26,11 +26,19 @@ num_cpus = "1.13.0"
 sled = { version = "0.34.6" }
 bincode = "1.3.3"
 once_cell = "1.8.0"
-rust-gpu-tools = { version = "0.4.0"}
+#rust-gpu-tools = { version = "0.4.0"}
+rust-gpu-tools = { git = "https://github.com/filecoin-project/rust-gpu-tools", branch = "master", default-features = false}
+
+
 
 [dev-dependencies]
 criterion = "0.3.4"
 rand = "0.8.4"
+
+[features]
+default = ["opencl"]
+cuda = ["rust-gpu-tools/cuda"]
+opencl = ["rust-gpu-tools/opencl"]
 
 [[bench]]
 name = "allocation"

--- a/scheduler/src/device/device_id.rs
+++ b/scheduler/src/device/device_id.rs
@@ -1,4 +1,4 @@
-use rust_gpu_tools::opencl::UniqueId;
+use rust_gpu_tools::UniqueId;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::hash::{Hash, Hasher};
@@ -34,7 +34,7 @@ impl Deref for DeviceId {
 }
 
 impl TryFrom<&str> for DeviceId {
-    type Error = rust_gpu_tools::opencl::GPUError;
+    type Error = rust_gpu_tools::GPUError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         Ok(Self(UniqueId::try_from(value)?))
@@ -42,7 +42,7 @@ impl TryFrom<&str> for DeviceId {
 }
 
 impl TryFrom<String> for DeviceId {
-    type Error = rust_gpu_tools::opencl::GPUError;
+    type Error = rust_gpu_tools::GPUError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         Ok(Self(UniqueId::try_from(value.as_str())?))

--- a/scheduler/src/device/mod.rs
+++ b/scheduler/src/device/mod.rs
@@ -1,12 +1,12 @@
 mod device_id;
 pub use device_id::DeviceId;
 
-use rust_gpu_tools::opencl::Device as ClDevice;
+use rust_gpu_tools::Device as GPUDevice;
 
 #[cfg(not(dummy_devices))]
 #[derive(Debug, Clone)]
 pub struct Device {
-    dev: ClDevice,
+    dev: GPUDevice,
     pub id: DeviceId,
 }
 
@@ -30,7 +30,7 @@ impl Device {
         self.dev.memory()
     }
 
-    pub fn get_inner(&self) -> ClDevice {
+    pub fn get_inner(&self) -> GPUDevice {
         self.dev.clone()
     }
 }
@@ -67,7 +67,7 @@ impl Devices {
 #[cfg(not(dummy_devices))]
 pub fn list_devices() -> Devices {
     let gpu_devices = {
-        ClDevice::all()
+        GPUDevice::all()
             .into_iter()
             .map(|dev| {
                 let unique_id = dev.unique_id();
@@ -89,7 +89,7 @@ pub fn list_devices() -> Devices {
 
 #[cfg(dummy_devices)]
 pub fn list_devices() -> Devices {
-    use rust_gpu_tools::opencl::UniqueId;
+    use rust_gpu_tools::UniqueId;
     use std::convert::TryFrom;
 
     let gpu_devices = (0..3)


### PR DESCRIPTION
Due to recent changes in rust-gpu-tools we need to add cuda and opencl features flags to the scheduler and client library. It seems that we do not really need those features, but devices' characteristics like memory, name, and so on may be retrieved differently depending on either those features are enabled or not, which can lead to compilation errors.